### PR TITLE
Added PGM_P pointer type to AVR pgmspace compatibility

### DIFF
--- a/pic32/cores/pic32/avr/pgmspace.h
+++ b/pic32/cores/pic32/avr/pgmspace.h
@@ -9,6 +9,10 @@
 #endif
 #define PROGMEM
 
+#ifndef PGM_P
+#define PGM_P const char *
+#endif
+
 #ifdef PSTR
 #undef PSTR
 #endif


### PR DESCRIPTION
Came across an instance where `PGM_P` was being used to point to a PROGMEM string.  We lacked that alias.