### PR TITLE
Fixed DTWI OPT_BOARD_INTERNAL problem

### DIFF
--- a/pic32/libraries/Wire/DTWI.cpp
+++ b/pic32/libraries/Wire/DTWI.cpp
@@ -43,6 +43,10 @@
 /*  Revision History:                                                   */
 /*    8/4/2014(KeithV): Created                                         */
 /************************************************************************/
+
+#define OPT_SYSTEM_INTERNAL
+#define OPT_BOARD_INTERNAL
+
 #include <DTWI.h>
 
 #define I2C_BUS_COLLISION_EVENT     0b001

--- a/pic32/libraries/Wire/DTWI.h
+++ b/pic32/libraries/Wire/DTWI.h
@@ -46,8 +46,6 @@
 #if !defined(_DTWI_H_)
 #define	_DTWI_H_
 
-#define OPT_SYSTEM_INTERNAL
-#define OPT_BOARD_INTERNAL
 #include	<WProgram.h>
 
 /* ------------------------------------------------------------ */
@@ -259,8 +257,7 @@ public:
     bool setNAK(uint32_t cbToNak);
     I2C_STATUS getStatus(void);
 };
-
-#ifdef _DTWI0_BASE
+#if (NUM_DTWI_PORTS > 0)
 class DTWI0 : public DTWI {
 
     // needed to get to pDTWI
@@ -274,7 +271,7 @@ public:
 };
 #endif
 
-#ifdef _DTWI1_BASE
+#if (NUM_DTWI_PORTS > 1)
 class DTWI1 : public DTWI {
 
     // needed to get to pDTWI
@@ -288,7 +285,7 @@ public:
 };
 #endif
 
-#ifdef _DTWI2_BASE
+#if (NUM_DTWI_PORTS > 2)
 class DTWI2 : public DTWI {
 
     // needed to get to pDTWI
@@ -302,7 +299,7 @@ public:
 };
 #endif
 
-#ifdef _DTWI3_BASE
+#if (NUM_DTWI_PORTS > 3)
 class DTWI3 : public DTWI {
 
     // needed to get to pDTWI
@@ -316,7 +313,7 @@ public:
 };
 #endif
 
-#ifdef _DTWI4_BASE
+#if (NUM_DTWI_PORTS > 4)
 class DTWI4 : public DTWI {
 
     // needed to get to pDTWI


### PR DESCRIPTION
There is a problem with DTWI that completely breaks it in UECIDE.

A decision was made to require `OPT_BOARD_INTERNAL` to be set in the DTWI header and key the creation of `DTWI0` etc on the `_DTWI0_BASE` and similar defines - instead of doing what DSPI does, which is use the `NUM_DTWI_PORTS` define (after all, that's the whole point of it).  The `NUM_DTWI_PORTS` does not require `OPT_BOARD_INTERNAL` to be set, which is good, because there are times when that won't be set due to the `Boards_Defs.h` file not being included at that specific time because it, or one of the parent header files, has already been included once before `OPT_BOARD_INTERNAL` gets set.

This fixes that problem by making DTWI work the same way as DSPI which doesn't care in the header about anything that is protected by `OPT_BOARD_INTERNAL`.