### PR TITLE
Expand OneWire to cover all PIC32 devices not just MX devices

### DIFF
--- a/pic32/libraries/OneWire/OneWire.h
+++ b/pic32/libraries/OneWire/OneWire.h
@@ -61,7 +61,7 @@
 #define DIRECT_WRITE_LOW(base, mask)    ((*(base+2)) &= ~(mask))
 #define DIRECT_WRITE_HIGH(base, mask)   ((*(base+2)) |= (mask))
 
-#elif defined(__PIC32MX__)
+#elif defined(__PIC32__)
 
 #define PIN_TO_BASEREG(pin)             (portModeRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))


### PR DESCRIPTION
The header for OneWire defined the port register interface using `__PIC32MX__` which excluded the MZ chips.  By changing it to `__PIC32__` it covers all variations of the PIC32 regardless.