### PR TITLE
Fixed problem where SPI transaction settings weren't getting applied

### DIFF
--- a/pic32/libraries/SPI/SPI.h
+++ b/pic32/libraries/SPI/SPI.h
@@ -129,7 +129,6 @@ private:
                 con |= ((1 << _SPICON_CKP) | (0 << _SPICON_CKE));
                 break;
         }
-        con |= (1 << _SPICON_ON);
     }
     uint8_t brg;
     uint8_t con;
@@ -181,8 +180,10 @@ public:
 
         inTransactionFlag = 1;
 #endif
+        pspi->sxCon.clr = (1 << _SPICON_ON);
         pspi->sxBrg.reg = settings.brg;
         pspi->sxCon.reg = settings.con;
+        pspi->sxCon.set = (1 << _SPICON_ON);
     }
 
     // Write to the SPI bus (MOSI pin) and also receive (MISO pin)


### PR DESCRIPTION
It's important to turn off the SPI module before applying the new settings and then turn it on after the settings have been applied - otherwise it really doesn't like it.