### PR TITLE
Fixed some compilation warnings in the Hardware Serial and CDC drivers

### DIFF
--- a/pic32/cores/pic32/HardwareSerial.cpp
+++ b/pic32/cores/pic32/HardwareSerial.cpp
@@ -725,7 +725,7 @@ void	USBresetRoutine(void)
 // Need to return FALSE if we need USB to hold off for awhile
 boolean	USBstoreDataRoutine(const byte *buffer, int length)
 {
-    unsigned int	i;
+    int	i;
 
     // If we have a receive callback defined then repeatedly
     // call it with each character.

--- a/pic32/cores/pic32/HardwareSerial_usb.c
+++ b/pic32/cores/pic32/HardwareSerial_usb.c
@@ -249,7 +249,7 @@ static void	usb_device_default()
 	MCF_USB_OTG_CTL |= MCF_USB_OTG_CTL_ODD_RST;
 	MCF_USB_OTG_CTL &= ~MCF_USB_OTG_CTL_ODD_RST;
 
-	memset(bdts, 0, BDT_RAM_SIZE);
+	memset((void *)bdts, 0, BDT_RAM_SIZE);
 	memset(endpoints, 0, sizeof(endpoints));
 
 	assert(configuration_descriptor);
@@ -287,7 +287,7 @@ void	usb_device_enqueue(int endpoint, boolean tx, byte *buffer, int length)
 		odd	=	endpoints[endpoint].bdtodd[tx];
 
 		// initialize the bdt entry
-		bdt	=	MYBDT(endpoint, tx, odd);
+		bdt	=	(struct bdt *)MYBDT(endpoint, tx, odd);
 		bdt->buffer	=	(byte *)TF_LITTLE(KVA_TO_PA((int)buffer));
 		flags	=	TF_LITTLE(bdt->flags);
 		assert(! (flags & BD_FLAGS_OWN));


### PR DESCRIPTION
A couple of variable type mismatches (signed / unsigned, volatile / nonvolatile) caused messy compilation warnings.