### PR TITLE
Fix for issue #67: Every entry in boards.txt overrides platform.txt f…

### DIFF
--- a/pic32/boards.txt
+++ b/pic32/boards.txt
@@ -79,12 +79,6 @@ cerebot_mx3ck.ccflags=ffff
 cerebot_mx3ck.ldscript=chipKIT-application-32MX320F128.ld
 # end of new items
 
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-cerebot_mx3ck.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-cerebot_mx3ck.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-
 cerebot_mx3ck.upload.protocol=stk500v2
 cerebot_mx3ck.upload.maximum_size=126976
 cerebot_mx3ck.upload.speed=115200
@@ -116,12 +110,6 @@ chipkit_mx3.board.define=
 chipkit_mx3.ccflags=ffff
 chipkit_mx3.ldscript=chipKIT-application-32MX320F128.ld
 # end of new items
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-chipkit_mx3.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-chipkit_mx3.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 
 chipkit_mx3.upload.protocol=stk500v2
 chipkit_mx3.upload.maximum_size=126976
@@ -155,12 +143,6 @@ cerebot_mx3ck_512.board.define=
 cerebot_mx3ck_512.ccflags=ffff
 cerebot_mx3ck_512.ldscript=chipKIT-application-32MX340F512.ld
 # end of new items
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-cerebot_mx3ck_512.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-cerebot_mx3ck_512.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 
 cerebot_mx3ck_512.upload.protocol=stk500v2
 cerebot_mx3ck_512.upload.maximum_size=520192
@@ -323,12 +305,6 @@ chipkit_Pi.board.define=
 chipkit_Pi.ldscript=chipKIT-application-32MX250F128.ld
 # end of new items
 
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-chipkit_Pi.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-chipkit_Pi.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-
 chipkit_Pi.upload.protocol=stk500v2
 # 128KB - 4K for EEPROM - 4K for bootloader
 chipkit_Pi.upload.maximum_size=122880
@@ -364,12 +340,6 @@ chipkit_Pi_USB_Serial.ccflags=-Map="map.map"
 chipkit_Pi_USB_Serial.ldscript=chipKIT-application-32MX250F128.ld
 # end of new items
 
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-chipkit_Pi_USB_Serial.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-chipkit_Pi_USB_Serial.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-
 chipkit_Pi_USB_Serial.upload.protocol=stk500v2
 # 128KB - 4K for EEPROM - 4K for bootloader
 chipkit_Pi_USB_Serial.upload.maximum_size=122880
@@ -403,12 +373,6 @@ cmod.board.define=
 cmod.ccflags=ffff
 cmod.ldscript=chipKIT-application-32MX150F128.ld
 # end of new items
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-cmod.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-cmod.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 
 cmod.upload.protocol=stk500v2
 # 128KB - 4K for EEPROM
@@ -580,12 +544,6 @@ usbono_pic32.ldscript=chipKIT-application-32MX440F512.ld
 #chipKIT-UNO32-application-32MX320F128L.ld
 # end of new items
 
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-#usbono_pic32.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-#usbono_pic32.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-
 usbono_pic32.upload.protocol=stk500v2
 usbono_pic32.upload.maximum_size=520192
 usbono_pic32.upload.speed=115200
@@ -622,12 +580,6 @@ chipkit_DP32.ccflags=-Map="map.map"
 chipkit_DP32.ldscript=chipKIT-application-32MX250F128.ld
 # end of new items
 
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-chipkit_DP32.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-chipkit_DP32.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-
 chipkit_DP32.upload.protocol=stk500v2
 # 128KB - 4K for EEPROM - 4K for bootloader
 chipkit_DP32.upload.maximum_size=122880
@@ -661,12 +613,6 @@ fubarino_mini_dev.build.extra_flags=-D_USE_USB_FOR_SERIAL_
 fubarino_mini_dev.ccflags=-Map="map.map"
 fubarino_mini_dev.ldscript=chipKIT-application-32MX250F128.ld
 
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-fubarino_mini_dev.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-fubarino_mini_dev.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-
 fubarino_mini_dev.upload.protocol=stk500v2
 # 128KB - 4K for EEPROM - 4K for bootloader
 fubarino_mini_dev.upload.maximum_size=122880
@@ -698,12 +644,6 @@ fubarino_mini.build.extra_flags=-D_USE_USB_FOR_SERIAL_
 
 fubarino_mini.ccflags=-Map="map.map"
 fubarino_mini.ldscript=chipKIT-application-32MX250F128.ld
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-fubarino_mini.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-fubarino_mini.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 
 fubarino_mini.upload.protocol=stk500v2
 # 128KB - 4K for EEPROM - 4K for bootloader
@@ -737,11 +677,6 @@ fubarino_mini.build.variant=Fubarino_Mini
 #fubarino_mini_dbg.ldscript=chipKIT-application-32MX250F128-nobootloader.ld
 ## end of new items
 #
-## Use a high -Gnum for devices that have less than 64K of data memory
-## For -G1024, objects 1024 bytes or smaller will be accessed by
-## gp-relative addressing
-#fubarino_mini_dbg.compiler.c.flags=-O0 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-#fubarino_mini_dbg.compiler.cpp.flags=-O0 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 #fubarino_mini_dbg.upload.protocol=stk500v2
 ## 128KB - 4K for EEPROM - 4K for bootloader
 #fubarino_mini_dbg.upload.maximum_size=122880
@@ -1021,12 +956,6 @@ chipkit_uc32.ccflags=ffff
 chipkit_uc32.ldscript=chipKIT-application-32MX340F512.ld
 # end of new items
 
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-chipkit_uc32.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-chipkit_uc32.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-
 chipkit_uc32.upload.protocol=stk500v2
 chipkit_uc32.upload.maximum_size=520192
 chipkit_uc32.upload.speed=115200
@@ -1058,12 +987,6 @@ uc32_pmod.board.define=
 uc32_pmod.ccflags=ffff
 uc32_pmod.ldscript=chipKIT-application-32MX340F512.ld
 # end of new items
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-uc32_pmod.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-uc32_pmod.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 
 uc32_pmod.upload.protocol=stk500v2
 uc32_pmod.upload.maximum_size=520192
@@ -1097,12 +1020,6 @@ uno_pic32.board.define=
 uno_pic32.ccflags=ffff
 uno_pic32.ldscript=chipKIT-application-32MX320F128.ld
 # end of new items
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-uno_pic32.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-uno_pic32.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 
 uno_pic32.upload.tool=pic32prog
 uno_pic32.upload.protocol=stk500v2
@@ -1138,12 +1055,6 @@ uno_pmod.board.define=
 uno_pmod.ccflags=ffff
 uno_pmod.ldscript=chipKIT-application-32MX320F128.ld
 # end of new items
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-uno_pmod.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-uno_pmod.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 
 uno_pic32.upload.tool=pic32prog
 uno_pmod.upload.protocol=stk500v2
@@ -1280,12 +1191,6 @@ openbci.build.extra_flags=-D_USE_USB_FOR_SERIAL_
 openbci.ccflags=-Map="map.map"
 openbci.ldscript=chipKIT-application-32MX250F128.ld
 # end of new items
-
-# Use a high -Gnum for devices that have less than 64K of data memory
-# For -G1024, objects 1024 bytes or smaller will be accessed by
-# gp-relative addressing
-openbci.compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
-openbci.compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 
 openbci.upload.protocol=stk500v2
 # 128KB - 4K for EEPROM - 4K for bootloader

--- a/pic32/platform.txt
+++ b/pic32/platform.txt
@@ -3,10 +3,13 @@ name=chipKIT
 version=1.6.0
 compiler.c.cmd=pic32-gcc
 compiler.path={runtime.hardware.path}/pic32/compiler/pic32-tools/bin/
-compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -g3 -mdebugger -Wcast-align -fno-short-double -fframe-base-loclist
+# Use a high -Gnum for devices that have less than 64K of data memory
+# For -G1024, objects 1024 bytes or smaller will be accessed by
+# gp-relative addressing
+compiler.c.flags=-O2 -c -mno-smart-io -w -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 compiler.c.extra_flags=-MMD
 compiler.cpp.cmd=pic32-g++
-compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -g3 -mdebugger -Wcast-align -fno-short-double -fframe-base-loclist
+compiler.cpp.flags=-O2 -c -mno-smart-io -w -fno-exceptions -ffunction-sections -fdata-sections -G1024 -g -mdebugger -Wcast-align -fno-short-double
 compiler.cpp.extra_flags=-MMD
 compiler.S.flags=-O2 -g1 -c -Wa,--gdwarf-2
 compiler.ar.cmd=pic32-ar


### PR DESCRIPTION
…or compiler.c.flags. This has now been fixed, and only platform.txt contains compiler.c.flags. (Same for compiler.cpp.flags)

I've done some limited testing (making sure that a sample sketch compiles on all boards, and runs on a representative sample of boards) and this change does not appear to break anything. Notice however that we are using the -G1024 command line option of all boards, not just the ones with limited Flash. Based on the comments in the boards.txt file, I'm not sure if this is always needed or not.

Another change is -g rather than -g3. It's not clear to me what -g3 does compared with -g.

Another change is that we don't use the -fframe-base-loclist option.

Note that none of these are 'changes', since this PR doesn't actually cause our compiler to have any different options than it did before. This is because every board (in the boards.txt file)  was over-riding the default values in platform.txt. Now the value in platform.txt is what was in boards.txt for each board, but we've also removed all of the (identical) option settings in the boards.txt file.