### PR TITLE
Hopefully final fix for issue #102.

### DIFF
--- a/pic32/platform.txt
+++ b/pic32/platform.txt
@@ -29,7 +29,7 @@ compiler.elf2hex.cmd=pic32-bin2hex
 compiler.elf2hex.flags=-a
 compiler.elf2hex.extra_flags=
 compiler.c.elf.cmd=pic32-g++
-compiler.c.elf.flags=-Os -Wl,-M={build.path}/sketch.map,--gc-sections -mdebugger -mno-peripheral-libs -nostartfiles 
+compiler.c.elf.flags=-Os -Wl,-Map={build.path}/sketch.map,--gc-sections -mdebugger -mno-peripheral-libs -nostartfiles 
 compiler.c.elf.extra_flags=
 compiler.size.cmd=pic32-size
 compiler.cpudef=-mprocessor=

--- a/pic32/platform.txt
+++ b/pic32/platform.txt
@@ -29,7 +29,7 @@ compiler.elf2hex.cmd=pic32-bin2hex
 compiler.elf2hex.flags=-a
 compiler.elf2hex.extra_flags=
 compiler.c.elf.cmd=pic32-g++
-compiler.c.elf.flags=-Os -Wl,--gc-sections -mdebugger -mno-peripheral-libs -nostartfiles -M={build.path}/sketch.map
+compiler.c.elf.flags=-Os -Wl,-M={build.path}/sketch.map,--gc-sections -mdebugger -mno-peripheral-libs -nostartfiles 
 compiler.c.elf.extra_flags=
 compiler.size.cmd=pic32-size
 compiler.cpudef=-mprocessor=


### PR DESCRIPTION
The linker command line now has sane parameters for --gc-sections and the map file path, and it appears to both properly garbage collect sections as well as generated the correct map file. Win!