### PR TITLE
PGM table used instead of macro in analog pin expansion

### DIFF
--- a/pic32/cores/pic32/wiring_analog.c
+++ b/pic32/cores/pic32/wiring_analog.c
@@ -161,7 +161,7 @@ int	tmp;
     // we have to manually find the actual digital pin so we can set the PIC registers.
 
     // if this doesn't map, than the analog pin was passed in.
-    if( ain != digital_pin_to_analog_PGM[pin] )
+    if( ain != digitalPinToAnalog(pin))
     {
         int i = 0;
 
@@ -169,7 +169,7 @@ int	tmp;
         for(i=0; i<NUM_DIGITAL_PINS; i++)
         {
             // we found the pin
-            if(ain == digital_pin_to_analog_PGM[i])
+            if(ain == digitalPinToAnalog(i))
             {
                 pin = i;
                 break;


### PR DESCRIPTION
Directly referencing a PGM table that may or may not exist (they are OPTIONAL in a board definition) instead of accessing the macro that may or may not return entries from that table (*but is required to exist in some form*) is bad.  Means that if you opt not to use the PGM table in your board definition then the whole core fails to compile.