### PR TITLE
Another tweak to chipKIT-core checksum

### DIFF
--- a/package_chipkit_index.json
+++ b/package_chipkit_index.json
@@ -14,7 +14,7 @@
           "category": "pic32",
           "url": "https://github.com/chipKIT32/chipKIT-core/releases/download/v1.0.1/chipkit-core-16778039.master-0d3a6ce.zip",
           "archiveFileName": "chipkit-core-16778039.master-0d3a6ce.zip",
-          "checksum": "SHA-256:21B25DBDA78427D5F5DE24F0D70951D7EEF9FF6236E083CB57EBA5EBFCF95A5A",
+          "checksum": "SHA-256:63B503606657467FA0040EB629FFF1BF7A86DA84E4608A7469294CA209BD1E3D",
           "help": {
             "online": "http://chipkit.net/started/learn-basics/"
           },


### PR DESCRIPTION
It appears that things now work OK for Windows.