### PR TITLE
Updated .json file to use new pic32-tools (Mac/Linux)

### DIFF
--- a/package_chipkit_index.json
+++ b/package_chipkit_index.json
@@ -85,32 +85,32 @@
               "size": "187130873"
             }, 
             {
-              "url": "https://github.com/chipKIT32/chipKIT-compiler-builds/releases/download/v1.0.1/pic32-tools-chipKIT-cxx-master-Darwin-image.zip",
+              "url": "https://github.com/chipKIT32/chipKIT-core/releases/download/v1.0.1/pic32-tools-chipKIT-cxx-master-Darwin-image.zip",
               "checksum": "SHA-256:CDF9B5E27BFAC5552BB212BF1D5EF44F32B829B47A1D1C182F2CF69CCE3B0D0E",
               "host": "i386-apple-darwin",
               "archiveFileName": "pic32-tools-chipKIT-cxx-master-Darwin-image.zip",
-              "size": "100202782"
+              "size": "103730351"
             }, 
             {
-              "url": "https://github.com/chipKIT32/chipKIT-compiler-builds/releases/download/1.40-rc.2/pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
+              "url": "https://github.com/chipKIT32/chipKIT-core/releases/download/v1.0.1/pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
               "checksum": "SHA-256:C84B033967E6E718009DA5558EB1BC95E484ED0D95A23DB98BB0556917FE534E",
               "host": "x86_64-linux-gnu",
               "archiveFileName": "pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
-              "size": "98961200"
+              "size": "105128692"
             }, 
             {
-              "url": "https://github.com/chipKIT32/chipKIT-compiler-builds/releases/download/1.40-rc.2/pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
+              "url": "https://github.com/chipKIT32/chipKIT-core/releases/download/v1.0.1/pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
               "checksum": "SHA-256:C84B033967E6E718009DA5558EB1BC95E484ED0D95A23DB98BB0556917FE534E",
               "host": "i686-pc-linux-gnu",
               "archiveFileName": "pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
-              "size": "98961200"
+              "size": "105128692"
             }, 
             {
-              "url": "https://github.com/chipKIT32/chipKIT-compiler-builds/releases/download/1.40-rc.2/pic32-tools-chipKIT-cxx-master-arm-linux-image.zip",
+              "url": "https://github.com/chipKIT32/chipKIT-core/releases/download/v1.0.1/pic32-tools-chipKIT-cxx-master-arm-linux-image.zip",
               "checksum": "SHA-256:AA0B155E60AE53872E55F8557A95C0F995A964BCE65A9EE9138FC9AD1EB81019",
               "host": "i686-arm-gnu",
               "archiveFileName": "pic32-tools-chipKIT-cxx-master-arm-linux-image.zip",
-              "size": "99010758"
+              "size": "102719933"
             }
           ]
         },

--- a/package_chipkit_index.json
+++ b/package_chipkit_index.json
@@ -86,28 +86,28 @@
             }, 
             {
               "url": "https://github.com/chipKIT32/chipKIT-compiler-builds/releases/download/1.40-rc.2/pic32-tools-chipKIT-cxx-master-Darwin-image.zip",
-              "checksum": "SHA-256:8527857b562fb1982979f43d7b2edf1fc51fa36507ee4b2ddd94c42a9031b5e7",
+              "checksum": "SHA-256:CDF9B5E27BFAC5552BB212BF1D5EF44F32B829B47A1D1C182F2CF69CCE3B0D0E",
               "host": "i386-apple-darwin",
               "archiveFileName": "pic32-tools-chipKIT-cxx-master-Darwin-image.zip",
               "size": "100202782"
             }, 
             {
               "url": "https://github.com/chipKIT32/chipKIT-compiler-builds/releases/download/1.40-rc.2/pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
-              "checksum": "SHA-256:3a7c1fc3fdaab3bf0ff60daeb51eea8221e4071f13df5c3176fadcf9ac2f110a",
+              "checksum": "SHA-256:C84B033967E6E718009DA5558EB1BC95E484ED0D95A23DB98BB0556917FE534E",
               "host": "x86_64-linux-gnu",
               "archiveFileName": "pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
               "size": "98961200"
             }, 
             {
               "url": "https://github.com/chipKIT32/chipKIT-compiler-builds/releases/download/1.40-rc.2/pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
-              "checksum": "SHA-256:3a7c1fc3fdaab3bf0ff60daeb51eea8221e4071f13df5c3176fadcf9ac2f110a",
+              "checksum": "SHA-256:C84B033967E6E718009DA5558EB1BC95E484ED0D95A23DB98BB0556917FE534E",
               "host": "i686-pc-linux-gnu",
               "archiveFileName": "pic32-tools-chipKIT-cxx-master-Linux32-image.zip",
               "size": "98961200"
             }, 
             {
               "url": "https://github.com/chipKIT32/chipKIT-compiler-builds/releases/download/1.40-rc.2/pic32-tools-chipKIT-cxx-master-arm-linux-image.zip",
-              "checksum": "SHA-256:68a471fbe00266a10ad82ebc230963ed38b026364c32705997b229250aa066ed",
+              "checksum": "SHA-256:AA0B155E60AE53872E55F8557A95C0F995A964BCE65A9EE9138FC9AD1EB81019",
               "host": "i686-arm-gnu",
               "archiveFileName": "pic32-tools-chipKIT-cxx-master-arm-linux-image.zip",
               "size": "99010758"


### PR DESCRIPTION
I had to create new pic32-tools zip files (just like for Windows) without the *.py files in them, and uploaded them to the chipKIT-core v1.0.1 release, then updated the .json file to point to them (with updated lengths and SHA256 values)