### PR TITLE
Fixes for #156 (2MB parts don't have proper memory size), #152 (remov…

### DIFF
--- a/pic32/boards.txt
+++ b/pic32/boards.txt
@@ -1122,7 +1122,7 @@ chipkit_WiFire.ldscript=MZ-application-32MZ2048ECX.ld
 # end of new items
 
 chipkit_WiFire.upload.protocol=stk500v2
-chipkit_WiFire.upload.maximum_size=520192
+chipkit_WiFire.upload.maximum_size=2093056
 chipkit_WiFire.upload.speed=115200
 chipkit_WiFire.upload.tool=pic32prog
 

--- a/pic32/platform.txt
+++ b/pic32/platform.txt
@@ -70,10 +70,10 @@ compiler.elf2hex.extra_flags=
 # --------------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}"  {compiler.c.flags} -I{build.path} -mprocessor={build.mcu} -DF_CPU={build.f_cpu}  -DARDUINO={runtime.ide.version} -D{build.board} {compiler.define} {compiler.c.extra_flags} {build.extra_flags} -I{build.path}/sketch {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}"  {compiler.c.flags} -mprocessor={build.mcu} -DF_CPU={build.f_cpu}  -DARDUINO={runtime.ide.version} -D{build.board} {compiler.define} {compiler.c.extra_flags} {build.extra_flags} -I{build.path}/sketch {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}"  {compiler.cpp.flags} -I{build.path} -mprocessor={build.mcu} -DF_CPU={build.f_cpu}  -DARDUINO={runtime.ide.version} -D{build.board} {compiler.define} "{compiler.cpp.extra_flags}" {build.extra_flags} -I{build.path}/sketch {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}"  {compiler.cpp.flags} -mprocessor={build.mcu} -DF_CPU={build.f_cpu}  -DARDUINO={runtime.ide.version} -D{build.board} {compiler.define} "{compiler.cpp.extra_flags}" {build.extra_flags} -I{build.path}/sketch {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
 recipe.S.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.S.flags} -mprocessor={build.mcu} -DF_CPU={build.f_cpu}  -DARDUINO={runtime.ide.version} -D{build.board} {compiler.define} "{compiler.cpp.extra_flags}" {build.extra_flags} -I{build.path}/sketch {includes} "{source_file}" -o "{object_file}"

--- a/pic32/variants/Cerebot_32MX7/boards.txt
+++ b/pic32/variants/Cerebot_32MX7/boards.txt
@@ -4,7 +4,7 @@ cerebot32mx7.group=Cerebot
 
 # new items
 cerebot32mx7.platform=pic32
-cerebot32mx7.board=BOARD_CEREBOT_32MX7_
+cerebot32mx7.board=_BOARD_CEREBOT_32MX7_
 cerebot32mx7.board.define=
 cerebot32mx7.ccflags=ffff
 cerebot32mx7.ldscript=chipKIT-application-32MX795F512.ld

--- a/pic32/variants/Cerebot_MX7cK/boards.txt
+++ b/pic32/variants/Cerebot_MX7cK/boards.txt
@@ -4,7 +4,7 @@ cerebot_mx7ck.group=Cerebot
 
 # new items
 cerebot_mx7ck.platform=pic32
-cerebot_mx7ck.board=BOARD_CEREBOT_MX7CK_
+cerebot_mx7ck.board=_BOARD_CEREBOT_MX7CK_
 cerebot_mx7ck.board.define=
 cerebot_mx7ck.ccflags=ffff
 cerebot_mx7ck.ldscript=chipKIT-application-32MX795F512.ld
@@ -34,7 +34,7 @@ chipkit_pro_mx7.group=chipKIT
 
 # new items
 chipkit_pro_mx7.platform=pic32
-chipkit_pro_mx7.board=BOARD_CEREBOT_MX7CK_
+chipkit_pro_mx7.board=_BOARD_CEREBOT_MX7CK_
 chipkit_pro_mx7.board.define=
 chipkit_pro_mx7.ccflags=ffff
 chipkit_pro_mx7.ldscript=chipKIT-application-32MX795F512.ld


### PR DESCRIPTION
…e -I{build.path}), #150 (remove leading underscores for board names)