### PR TITLE
Fix for issue #144, #121, and #163

### DIFF
--- a/pic32/cores/pic32/HardwareSerial.cpp
+++ b/pic32/cores/pic32/HardwareSerial.cpp
@@ -171,7 +171,7 @@ void __attribute__((interrupt(),nomips16)) IntSer7Handler(void);
 **		any global variables used by the object.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 HardwareSerial::HardwareSerial(p32_uart * uartT, int irqT, int vecT, int iplT, int splT, isrFunc isrHandler, int pinT, int pinR, ppsFunctionType ppsT, ppsFunctionType ppsR)
 #else
 HardwareSerial::HardwareSerial(p32_uart * uartT, int irqT, int vecT, int iplT, int splT, isrFunc isrHandler)
@@ -187,7 +187,7 @@ HardwareSerial::HardwareSerial(p32_uart * uartT, int irqT, int vecT, int iplT, i
     isr  = isrHandler;
     rxIntr = NULL;
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 	pinTx = (uint8_t)pinT;
 	pinRx = (uint8_t)pinR;
 	ppsTx = ppsT;
@@ -239,7 +239,7 @@ void HardwareSerial::begin(unsigned long baudRate)
 	*/
 	purge();
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 
     // set the pins to digital, just in case they 
     // are analog pins. The serial controller will not
@@ -340,7 +340,7 @@ void HardwareSerial::begin(unsigned long baudRate, uint8_t address) {
 	*/
 	purge();
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 
     // set the pins to digital, just in case they 
     // are analog pins. The serial controller will not
@@ -1253,7 +1253,7 @@ void __attribute__((interrupt(), nomips16)) IntSer7Handler(void)
 */
 USBSerial		Serial(&rx_bufferUSB);
 #if defined(_SER0_BASE)
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 HardwareSerial Serial0((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL, _SER0_SPL, IntSer0Handler, _SER0_TX_PIN, _SER0_RX_PIN, _SER0_TX_OUT, _SER0_RX_IN);
 #else
 HardwareSerial Serial0((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL, _SER0_SPL, IntSer0Handler);
@@ -1268,7 +1268,7 @@ HardwareSerial Serial0((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IP
 ** however MZ have 6
 */
 #if defined(_SER0_BASE)
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 HardwareSerial Serial((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL, _SER0_SPL, IntSer0Handler, _SER0_TX_PIN, _SER0_RX_PIN, _SER0_TX_OUT, _SER0_RX_IN);
 #else
 HardwareSerial Serial((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL, _SER0_SPL, IntSer0Handler);
@@ -1278,7 +1278,7 @@ HardwareSerial Serial((p32_uart *)_SER0_BASE, _SER0_IRQ, _SER0_VECTOR, _SER0_IPL
 #endif	//defined(_USB) && defined(_USE_USB_FOR_SERIAL_)
 
 #if defined(_SER1_BASE)
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 HardwareSerial Serial1((p32_uart *)_SER1_BASE, _SER1_IRQ, _SER1_VECTOR, _SER1_IPL, _SER1_SPL, IntSer1Handler, _SER1_TX_PIN, _SER1_RX_PIN, _SER1_TX_OUT, _SER1_RX_IN);
 #else
 HardwareSerial Serial1((p32_uart *)_SER1_BASE, _SER1_IRQ, _SER1_VECTOR, _SER1_IPL, _SER1_SPL, IntSer1Handler);

--- a/pic32/cores/pic32/HardwareSerial.h
+++ b/pic32/cores/pic32/HardwareSerial.h
@@ -91,7 +91,7 @@ class HardwareSerial : public Stream
 		uint8_t			vec;		//interrupt vector for the UART
 		uint8_t			ipl;		//interrupt priority level
 		uint8_t			spl;		//interrupt sub-priority level
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 		uint8_t			pinTx;		//digital pin number of TX
 		uint8_t			pinRx;		//digital pin number for RX
 		ppsFunctionType	ppsTx;		//PPS select for UART TX
@@ -107,7 +107,7 @@ class HardwareSerial : public Stream
         void            (*rxIntr)(int); // Interrupt callback routine
 
 	public:
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 		HardwareSerial(p32_uart * uartP, int irq, int vec, int ipl, int spl, isrFunc isrHandler, int pinT, int pinR, ppsFunctionType ppsT, ppsFunctionType ppsR);
 #else
 		HardwareSerial(p32_uart * uartP, int irq, int vec, int ipl, int spl, isrFunc isrHandler);

--- a/pic32/cores/pic32/System_Defs.h
+++ b/pic32/cores/pic32/System_Defs.h
@@ -372,7 +372,7 @@
 #define	_SPI1_IPL_IPC	3		//interrupt priority for the IPC register
 #define	_SPI1_SPL_IPC	0		//interrupt subpriority for the IPC register
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX3XX__) || defined(__PIC32MX4XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 #define	_SPI2_IPL_ISR	IPL3SOFT    //interrupt priority for the ISR
 #define	_SPI2_IPL_IPC	3       //interrupt priority for the IPC register
 #define	_SPI2_SPL_IPC	0       //interrupt subpriority for the IPC register

--- a/pic32/cores/pic32/WInterrupts.c
+++ b/pic32/cores/pic32/WInterrupts.c
@@ -71,7 +71,7 @@ void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode)
     {
         intFunc[interruptNum]	=	userFunc;
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
         /* For devices with peripheral pin select (PPS), it is necessary to
         ** map the input function to the pin. This is done by loading the
         ** PPS input select register for the specific interrupt with the value

--- a/pic32/cores/pic32/pins_arduino.c
+++ b/pic32/cores/pic32/pins_arduino.c
@@ -41,7 +41,7 @@
 #include "pins_arduino.h"
 #include "p32_defs.h"
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__)
+#if defined(__PIC32_PPS__)
 //* General data tables to support PPS pin mapping on PIC32MX1xx/2xx devices.
 //*
 #if defined(OPT_BOARD_DATA)

--- a/pic32/cores/pic32/pins_arduino.h
+++ b/pic32/cores/pic32/pins_arduino.h
@@ -184,7 +184,7 @@
 #define	_PPS_OUT(P) (uint8_t)(P)
 #define _PPS_IN(P) (uint8_t)(((P) & 0x0F) | ((P) >> 4))
 
-#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#endif	// defined(__PIC32_PPS__)
 
 /* ------------------------------------------------------------ */
 /*					Pin Mapping Macros							*/
@@ -204,7 +204,7 @@
 #define	digitalPinToTimer(P)	digitalPinToTimerOC(P)
 #define digitalPinToCN(P) (NOT_CN_PIN)
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 // This macro returns a pointer to a p32_ioport structure as defined in p32_defs.h
 // For MX1xx and MX2xx devices, the port register map starts with the ANSELx register.
 #define portRegisters(P) ((p32_ioport *)(port_to_tris_PGM[P] - 0x0010))
@@ -266,7 +266,7 @@
 /* Data tables for PPS pin mapping support defined in pins_arduino.h
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 #if !defined(OPT_BOARD_DATA)
 
 extern const uint8_t output_compare_to_pps_sel_PGM[];

--- a/pic32/cores/pic32/wiring.c
+++ b/pic32/cores/pic32/wiring.c
@@ -250,7 +250,7 @@ void	_board_init(void);
 //*
 /* Currently, PPS is only available in PIC32MX1xx/PIC32MX2xx devices.
 */
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZ__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 
 // Locks all PPS functions so that calls to mapPpsInput() or mapPpsOutput() always fail.
 // You would use this function if you set up all of your PPS settings at the beginning
@@ -339,7 +339,7 @@ boolean mapPps(uint8_t pin, ppsFunctionType func)
 	
 }
 
-#endif	// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
+#endif	// defined(__PIC32_PPS__)
 
 //************************************************************************
 //*	Deal with the 'virtual' program button and SoftReset(). This allows

--- a/pic32/cores/pic32/wiring.h
+++ b/pic32/cores/pic32/wiring.h
@@ -412,7 +412,7 @@ extern const uint32_t _IMAGE_HEADER_ADDR;                       // a pointer to 
 	extern unsigned int	__PIC32_pbClk;
 #endif
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZ__)  || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 
 // PPS Support for PIC32MX1 and PIC32MX2 parts
 // Locks all PPS functions so that calls to mapPpsInput() or mapPpsOutput() always fail.
@@ -435,7 +435,7 @@ void unlockPps();
 // in a <pin> that can't be assigned to <func>, this function will return 'false'.
 boolean mapPps(uint8_t pin, ppsFunctionType func);
 
-#endif  // defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
+#endif  // defined(__PIC32_PPS__)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/pic32/cores/pic32/wiring_analog.c
+++ b/pic32/cores/pic32/wiring_analog.c
@@ -151,7 +151,7 @@ int	tmp;
 	/* Ensure that the pin associated with the analog channel is in analog
 	** input mode, and select the channel in the input mux.
 	*/
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 	p32_ioport *	iop;
 	uint16_t		bit;
 
@@ -207,7 +207,7 @@ int	tmp;
 	**  bit in AD1PCFG.
 	*/
 	AD1PCFGCLR = (1 << channelNumber);
-#endif		// defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MX47X__)
+#endif		// defined(__PIC32_PPS__)
 
 #if defined(__PIC32MZXX__)
 
@@ -458,7 +458,7 @@ int	_board_analogWrite(uint8_t pin, int val);
             if ((pwm_active & pwm_mask) == 0)
             {
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
                 volatile uint32_t *	pps;
 
                 /* On devices with peripheral pin select, it is necessary to connect

--- a/pic32/libraries/DSPI/DSPI.cpp
+++ b/pic32/libraries/DSPI/DSPI.cpp
@@ -121,7 +121,7 @@ static DSPI *	pdspi3 = 0;
 **		can be instantiated.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 DSPI::DSPI(int pinMI, int pinMO, ppsFunctionType ppsMI, ppsFunctionType ppsMO)
 #else
 DSPI::DSPI()
@@ -131,7 +131,7 @@ DSPI::DSPI()
 	pspi = 0;
 	cbCur = 0;
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 	pinMISO = (uint8_t)pinMI;
 	pinMOSI = (uint8_t)pinMO;
 	ppsMISO = ppsMI;
@@ -180,7 +180,7 @@ DSPI::init(uint8_t irqErr, uint8_t irqRx, uint8_t irqTx, isrFunc isrHandler) {
     isr = isrHandler;
 }
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 
 /* ------------------------------------------------------------ */
 /***	DSPI::begin
@@ -279,7 +279,7 @@ bool DSPI::begin(uint8_t pinT) {
 	volatile uint8_t    bTmp;   // volatile to make sure optimizer does not remove instruction
 	uint16_t		    brg;
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 	/* Map the SPI MISO to the appropriate pin.  Some chips need the
        pins to be set to the right mode, either for the IO functionality
        or to disable any analog on the pin.
@@ -1060,7 +1060,7 @@ DSPI::doDspiInterrupt() {
 **		Constructor.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 DSPI0::DSPI0() : DSPI(_DSPI0_MISO_PIN, _DSPI0_MOSI_PIN, _DSPI0_MISO_IN, _DSPI0_MOSI_OUT)
 #else
 DSPI0::DSPI0() 
@@ -1145,7 +1145,7 @@ DSPI0::disableInterruptTransfer() {
 **		Constructor.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 DSPI1::DSPI1() : DSPI(_DSPI1_MISO_PIN, _DSPI1_MOSI_PIN, _DSPI1_MISO_IN, _DSPI1_MOSI_OUT)
 #else
 DSPI1::DSPI1()
@@ -1231,7 +1231,7 @@ DSPI1::disableInterruptTransfer() {
 **		Constructor.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 DSPI2::DSPI2() : DSPI(_DSPI2_MISO_PIN, _DSPI2_MOSI_PIN, _DSPI2_MISO_IN, _DSPI2_MOSI_OUT)
 #else
 DSPI2::DSPI2()
@@ -1316,7 +1316,7 @@ DSPI2::disableInterruptTransfer() {
 **		Constructor.
 */
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 DSPI3::DSPI3() : DSPI(_DSPI3_MISO_PIN, _DSPI3_MOSI_PIN, _DSPI3_MISO_IN, _DSPI3_MOSI_OUT)
 #else
 DSPI3::DSPI3()

--- a/pic32/libraries/DSPI/DSPI.h
+++ b/pic32/libraries/DSPI/DSPI.h
@@ -126,7 +126,7 @@ private:
 	uint8_t				bPad;		//pad byte for some transfers
 	uint8_t				fRov;		//receive overflow error flag
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 	uint8_t				pinMISO;		//digital pin number for MISO
 	uint8_t				pinMOSI;		//digital pin number for MOSI
 	ppsFunctionType		ppsMISO;		//PPS select for SPI MISO
@@ -145,7 +145,7 @@ protected:
 	uint8_t				ipl;		//interrupt priority and sub-priority
 	uint8_t				pinSS;		//digital pin number for slave select pin
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 			DSPI (int pinMI, int pinMO, ppsFunctionType ppsMI, ppsFunctionType ppsMO);
 #else
 			DSPI();
@@ -159,7 +159,7 @@ public:
 */
 bool		begin();
 bool		begin(uint8_t pin);
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 bool        begin(uint8_t miso, uint8_t mosi);
 bool        begin(uint8_t miso, uint8_t mosi, uint8_t pin);
 #endif

--- a/pic32/libraries/SPI/SPI.cpp
+++ b/pic32/libraries/SPI/SPI.cpp
@@ -13,13 +13,13 @@
 
 #include "SPI.h"
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 SPIClass SPI(_DSPI0_BASE, _DSPI0_MISO_PIN, _DSPI0_MOSI_PIN, _DSPI0_MISO_IN, _DSPI0_MOSI_OUT);
 #else
 SPIClass SPI(_DSPI0_BASE);
 #endif
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
 SPIClass::SPIClass(uint32_t base, int pinMI, int pinMO, ppsFunctionType ppsMI, ppsFunctionType ppsMO) {
     pspi = (p32_spi *)base;
     pinMISO = pinMI;
@@ -38,7 +38,7 @@ void SPIClass::begin() {
     uint32_t sreg = disableInterrupts();
 
     if (!initialized) {
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
         pinMode(pinMISO, INPUT);
         mapPps(pinMISO, ppsMISO);
         pinMode(pinMOSI, OUTPUT);

--- a/pic32/libraries/SPI/SPI.h
+++ b/pic32/libraries/SPI/SPI.h
@@ -139,7 +139,7 @@ private:
 class SPIClass {
 public:
 
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
     SPIClass(uint32_t base, int pinMI, int pinMO, ppsFunctionType ppsMI, ppsFunctionType ppsMO);
 #else
     SPIClass(uint32_t base);
@@ -317,7 +317,7 @@ private:
     uint32_t inTransactionFlag;
 #endif
     p32_spi *pspi;
-#if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__) || defined(__PIC32MZXX__) || defined(__PIC32MX47X__)
+#if defined(__PIC32_PPS__)
     uint8_t             pinMISO;        //digital pin number for MISO
     uint8_t             pinMOSI;        //digital pin number for MOSI
     ppsFunctionType     ppsMISO;        //PPS select for SPI MISO

--- a/pic32/variants/CUI32stem/Board_Defs.h
+++ b/pic32/variants/CUI32stem/Board_Defs.h
@@ -299,20 +299,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI2. The pins for SPI2 stay the
-** same on all PIC32 devices. The pins for SPI1 move around,
-** and the ports beyond SPI2 aren't defined on some parts.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses the same port.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/Cerebot_32MX4/Board_Defs.h
+++ b/pic32/variants/Cerebot_32MX4/Board_Defs.h
@@ -318,18 +318,8 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2. Connector JB
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
 
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 **		DSPI0	connector JB
 **		DSPI1	connector J1
 */

--- a/pic32/variants/Cerebot_32MX7/Board_Defs.h
+++ b/pic32/variants/Cerebot_32MX7/Board_Defs.h
@@ -310,18 +310,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI4. Connector JF
-*/
-#define	_SPI_BASE		_SPI4_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI4_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI4_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI4_TX_IRQ
-#define	_SPI_VECTOR		_SPI_4_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 **		DSPI0	connector JD
 **		DSPI1	connector JE
 **		DSPI2	connector JF

--- a/pic32/variants/Cerebot_MX3cK/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX3cK/Board_Defs.h
@@ -301,18 +301,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2. Connector JE.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 **		DSPI0	connector JE
 **		DSPI1	connector JB
 */

--- a/pic32/variants/Cerebot_MX3cK_512/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX3cK_512/Board_Defs.h
@@ -319,18 +319,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2. Connector JE.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 **		DSPI0	connector JE
 **		DSPI1	connector JB
 */

--- a/pic32/variants/Cerebot_MX4cK/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX4cK/Board_Defs.h
@@ -319,18 +319,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2. Connector JB
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 **		DSPI0	connector JB
 **		DSPI1	connector J1
 */

--- a/pic32/variants/Cerebot_MX7cK/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX7cK/Board_Defs.h
@@ -311,18 +311,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard library SPI port uses SPI4. Connector JF
-*/
-#define	_SPI_BASE		_SPI4_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI4_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI4_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI4_TX_IRQ
-#define	_SPI_VECTOR		_SPI_4_VECTOR
-#define	_SPI_IPL_ISR	_SPI4_IPL_ISR
-#define	_SPI_IPL		_SPI4_IPL_IPC
-#define	_SPI_SPL		_SPI4_SPL_IPC
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 **		DSPI0	connector JD
 **		DSPI1	connector JE
 **		DSPI2	connector JF

--- a/pic32/variants/ChipKIT_Pi/Board_Defs.h
+++ b/pic32/variants/ChipKIT_Pi/Board_Defs.h
@@ -310,25 +310,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI1.
-*/
-#define	_SPI_BASE		_SPI1_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI1_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI1_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI1_TX_IRQ
-#define	_SPI_VECTOR		_SPI_1_VECTOR
-#define	_SPI_IPL_ISR	_SPI1_IPL_ISR
-#define	_SPI_IPL		_SPI1_IPL_IPC
-#define	_SPI_SPL		_SPI1_SPL_IPC
-
-/* SPI pin declarations
-*/
-#define _SPI_MISO_IN	PPS_IN_SDI1
-#define	_SPI_MISO_PIN	MISO
-#define _SPI_MOSI_OUT	PPS_OUT_SDO1
-#define	_SPI_MOSI_PIN	MOSI
-
-/* SPI1 
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI1_ERR_IRQ

--- a/pic32/variants/Cmod/Board_Defs.h
+++ b/pic32/variants/Cmod/Board_Defs.h
@@ -352,26 +352,8 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI1.
-*/
-#define	_SPI_BASE		_SPI1_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI1_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI1_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI1_TX_IRQ
-#define	_SPI_VECTOR		_SPI_1_VECTOR
-#define	_SPI_IPL_ISR	_SPI1_IPL_ISR
-#define	_SPI_IPL		_SPI1_IPL_IPC
-#define	_SPI_SPL		_SPI1_SPL_IPC
-
-/* SPI pin declarations
-*/
-#define _SPI_MISO_IN	PPS_IN_SDI1
-#define	_SPI_MISO_PIN	MISO
-#define _SPI_MOSI_OUT	PPS_OUT_SDO1
-#define	_SPI_MOSI_PIN	MOSI
-
-
-/* Full SPI1 on J1
+/* The Digilent DSPI and standard SPI libraries uses these ports.
+ * Full SPI1 on J1
 */
 #define	_DSPI0_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI1_ERR_IRQ

--- a/pic32/variants/DP32/Board_Defs.h
+++ b/pic32/variants/DP32/Board_Defs.h
@@ -316,25 +316,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI1.
-*/
-#define	_SPI_BASE		_SPI1_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI1_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI1_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI1_TX_IRQ
-#define	_SPI_VECTOR		_SPI_1_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* SPI pin declarations
-*/
-#define _SPI_MISO_IN	PPS_IN_SDI1
-#define	_SPI_MISO_PIN	MISO
-#define _SPI_MOSI_OUT	PPS_OUT_SDO1
-#define	_SPI_MOSI_PIN	MOSI
-
-/* SPI1 
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 // RA0  CS1     PGED3/VREF+/CVREF+/AN0/C3INC/RPA0/CTED1/PMD7/RA0 
 // RA4  SDO1    RPA4R = SDO1 = 3    

--- a/pic32/variants/Default_100/Board_Defs.h
+++ b/pic32/variants/Default_100/Board_Defs.h
@@ -302,20 +302,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI2. The pins for SPI2 stay the
-** same on all PIC32 devices. The pins for SPI1 move around,
-** and the ports beyond SPI2 aren't defined on some devices.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses the same port.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/Default_64/Board_Defs.h
+++ b/pic32/variants/Default_64/Board_Defs.h
@@ -299,20 +299,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI2. The pins for SPI2 stay the
-** same on all PIC32 devices. The pins for SPI1 move around,
-** and the ports beyond SPI2 aren't defined on some parts.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses the same port.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/Fubarino_Mini/Board_Defs.h
+++ b/pic32/variants/Fubarino_Mini/Board_Defs.h
@@ -315,27 +315,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI2. The pins for SPI2 stay the
-** same on all PIC32 devices. The pins for SPI1 move around,
-** and the ports beyond SPI2 aren't defined on some parts.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* SPI pin declarations
-*/
-#define _SPI_MISO_IN	PPS_IN_SDI2
-#define	_SPI_MISO_PIN	MISO
-#define _SPI_MOSI_OUT	PPS_OUT_SDO2
-#define	_SPI_MOSI_PIN	MOSI
-
-/* SPI1
+/* The Digilent DSPI and standard SPI libraries uses these ports.
  * Note SCK1 only comes out B14, which is Arduino pin 3
  */
 #define	_DSPI0_BASE			_SPI1_BASE_ADDRESS

--- a/pic32/variants/Fubarino_SD/Board_Defs.h
+++ b/pic32/variants/Fubarino_SD/Board_Defs.h
@@ -383,20 +383,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI2. The pins for SPI2 stay the
-** same on all PIC32 devices. The pins for SPI1 move around,
-** and the ports beyond SPI2 aren't defined on some parts.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses the same port.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/Fubarino_SDZ/Board_Defs.h
+++ b/pic32/variants/Fubarino_SDZ/Board_Defs.h
@@ -335,7 +335,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /* Serial port 0 uses UART1
  * TX on pin 29 (RF5), RX on pin 28 (RF4)
 */
-#define	_SER0_BASE      ((uint32_t) &U1MODE)
+#define	_SER0_BASE      _UART1_BASE_ADDRESS
 #define	_SER0_IRQ       _UART1_FAULT_VECTOR
 #define	_SER0_VECTOR    _UART1_FAULT_VECTOR
 #define	_SER0_IPL_ISR   IPL2SRS
@@ -349,7 +349,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /* Serial port 1 uses UART1; this goes to pins 39&40
  /// TODO: Update to match Fubarino SD
 */
-#define	_SER1_BASE		((uint32_t) &U2MODE)
+#define	_SER1_BASE		_UART2_BASE_ADDRESS
 #define	_SER1_IRQ		_UART2_FAULT_VECTOR
 #define	_SER1_VECTOR	_UART2_FAULT_VECTOR
 #define	_SER1_IPL_ISR	IPL2SRS
@@ -365,26 +365,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	IPL3SRS
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* SPI pin declarations
-*/
-#define _SPI_MISO_IN	PPS_IN_SDI2
-#define	_SPI_MISO_PIN	MISO
-#define _SPI_MOSI_OUT	PPS_OUT_SDO2
-#define	_SPI_MOSI_PIN	MOSI
-
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 
 // same as the default SPI port
@@ -456,7 +437,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /* The standard I2C port uses I2C4 (SCL4/SDA4). These come to pins
 ** A4/A5 pins 18/19 on the analog connector.
 */
-#define	_TWI_BASE		((uint32_t) &I2C4CON)
+#define	_TWI_BASE		_I2C4_BASE_ADDRESS
 #define	_TWI_BUS_IRQ	_I2C4_BUS_VECTOR
 #define	_TWI_SLV_IRQ	_I2C4_SLAVE_VECTOR
 #define	_TWI_MST_IRQ	_I2C4_MASTER_VECTOR
@@ -469,7 +450,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 **		DTWI0 is SDA2/SCL2 on A4/A5 pins 18/19 (see above comment).
 */
 
-#define	_DTWI0_BASE		((uint32_t) &I2C4CON)
+#define	_DTWI0_BASE		_I2C4_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C4_BUS_VECTOR
 #define	_DTWI0_VECTOR	_I2C4_BUS_VECTOR
 #define	_DTWI0_IPL_ISR	IPL3SRS 

--- a/pic32/variants/Max32/Board_Defs.h
+++ b/pic32/variants/Max32/Board_Defs.h
@@ -330,18 +330,7 @@ extern const uint32_t   digital_pin_to_cn_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	_SPI2_IPL_ISR
-#define	_SPI_IPL		_SPI2_IPL_IPC
-#define	_SPI_SPL		_SPI2_SPL_IPC
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/Olimex_PIC32_Pinguino/Board_Defs.h
+++ b/pic32/variants/Olimex_PIC32_Pinguino/Board_Defs.h
@@ -330,20 +330,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI2. The pins for SPI2 stay the
-** same on all PIC32 devices. The pins for SPI1 move around,
-** and the ports beyond SPI2 aren't defined on some parts.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define	_SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses the same port.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/OpenScope/Board_Defs.h
+++ b/pic32/variants/OpenScope/Board_Defs.h
@@ -396,7 +396,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 /* Serial port 0 uses UART5
 */
-#define	_SER0_BASE      ((uint32_t) &U5MODE)
+#define	_SER0_BASE      _UART5_BASE_ADDRESS
 #define	_SER0_IRQ       _UART5_FAULT_VECTOR
 #define	_SER0_VECTOR    _UART5_FAULT_VECTOR
 #define	_SER0_IPL_ISR   IPL2SRS
@@ -409,7 +409,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 /* Serial port 1 uses UART1; this goes to pins 39&40
 */
-#define	_SER1_BASE		((uint32_t) &U1MODE)
+#define	_SER1_BASE		_UART1_BASE_ADDRESS
 #define	_SER1_IRQ		_UART1_FAULT_VECTOR
 #define	_SER1_VECTOR	_UART1_FAULT_VECTOR
 #define	_SER1_IPL_ISR	IPL2SRS
@@ -425,30 +425,11 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		((uint32_t) &SPI2CON)
-#define _SPI_ERR_IRQ	_SPI2_FAULT_VECTOR
-#define	_SPI_RX_IRQ		_SPI2_RX_VECTOR
-#define	_SPI_TX_IRQ		_SPI2_TX_VECTOR
-#define	_SPI_VECTOR		_SPI2_FAULT_VECTOR
-#define _SPI_IPL_ISR	IPL3SRS
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* SPI pin declarations
-*/
-#define _SPI_MISO_IN	PPS_IN_SDI2
-#define	_SPI_MISO_PIN	MISO
-#define _SPI_MOSI_OUT	PPS_OUT_SDO2
-#define	_SPI_MOSI_PIN	MOSI
-
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 
 // same as the default SPI port
-#define	_DSPI0_BASE			((uint32_t) &SPI2CON)
+#define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_FAULT_VECTOR
 #define	_DSPI0_RX_IRQ		_SPI2_RX_VECTOR
 #define	_DSPI0_TX_IRQ		_SPI2_TX_VECTOR
@@ -463,7 +444,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DSPI0_MOSI_PIN		MOSI		    
 
 // MRF24 SPI
-#define	_DSPI1_BASE			((uint32_t) &SPI4CON)
+#define	_DSPI1_BASE			_SPI4_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI4_FAULT_VECTOR
 #define	_DSPI1_RX_IRQ		_SPI4_RX_VECTOR
 #define	_DSPI1_TX_IRQ		_SPI4_TX_VECTOR
@@ -478,7 +459,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DSPI1_MOSI_PIN		58		        
 
 // SD Card
-#define	_DSPI2_BASE			((uint32_t) &SPI6CON)
+#define	_DSPI2_BASE			_SPI6_BASE_ADDRESS
 #define	_DSPI2_ERR_IRQ		_SPI6_FAULT_VECTOR
 #define	_DSPI2_RX_IRQ		_SPI6_RX_VECTOR
 #define	_DSPI2_TX_IRQ		_SPI6_TX_VECTOR
@@ -493,7 +474,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DSPI2_MOSI_PIN		54		    
 
 // SPI DAC
-#define	_DSPI3_BASE			((uint32_t) &SPI3CON)
+#define	_DSPI3_BASE			_SPI3_BASE_ADDRESS
 #define	_DSPI3_ERR_IRQ		_SPI3_FAULT_VECTOR
 #define	_DSPI3_RX_IRQ		_SPI3_RX_VECTOR
 #define	_DSPI3_TX_IRQ		_SPI3_TX_VECTOR
@@ -518,7 +499,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 **		DTWI0 is SDA5/SCL5 on pins 5/12
 */
 
-#define	_DTWI0_BASE		((uint32_t) &I2C5CON)
+#define	_DTWI0_BASE		_I2C5_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C5_BUS_VECTOR
 #define	_DTWI0_VECTOR	_I2C5_BUS_VECTOR
 #define	_DTWI0_IPL_ISR	IPL3SRS 

--- a/pic32/variants/Uno32/Board_Defs.h
+++ b/pic32/variants/Uno32/Board_Defs.h
@@ -311,18 +311,7 @@ extern const uint32_t   digital_pin_to_cn_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/Uno32_Pmod_Shield/Board_Defs.h
+++ b/pic32/variants/Uno32_Pmod_Shield/Board_Defs.h
@@ -315,18 +315,7 @@ extern const uint32_t   digital_pin_to_cn_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/WF32/Board_Defs.h
+++ b/pic32/variants/WF32/Board_Defs.h
@@ -336,18 +336,7 @@ extern const uint8_t 	digital_pin_to_analog_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/WiFire/Board_Defs.h
+++ b/pic32/variants/WiFire/Board_Defs.h
@@ -346,7 +346,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 /* Serial port 0 uses UART1
 */
-#define	_SER0_BASE      ((uint32_t) &U4MODE)
+#define	_SER0_BASE      _UART4_BASE_ADDRESS
 #define	_SER0_IRQ       _UART4_FAULT_VECTOR
 #define	_SER0_VECTOR    _UART4_FAULT_VECTOR
 #define	_SER0_IPL_ISR   IPL2SRS
@@ -359,7 +359,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 /* Serial port 1 uses UART1; this goes to pins 39&40
 */
-#define	_SER1_BASE		((uint32_t) &U1MODE)
+#define	_SER1_BASE		_UART1_BASE_ADDRESS
 #define	_SER1_IRQ		_UART1_FAULT_VECTOR
 #define	_SER1_VECTOR	_UART1_FAULT_VECTOR
 #define	_SER1_IPL_ISR	IPL2SRS
@@ -375,30 +375,11 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		((uint32_t) &SPI2CON)
-#define _SPI_ERR_IRQ	_SPI2_FAULT_VECTOR
-#define	_SPI_RX_IRQ		_SPI2_RX_VECTOR
-#define	_SPI_TX_IRQ		_SPI2_TX_VECTOR
-#define	_SPI_VECTOR		_SPI2_FAULT_VECTOR
-#define _SPI_IPL_ISR	IPL3SRS
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* SPI pin declarations
-*/
-#define _SPI_MISO_IN	PPS_IN_SDI2
-#define	_SPI_MISO_PIN	MISO
-#define _SPI_MOSI_OUT	PPS_OUT_SDO2
-#define	_SPI_MOSI_PIN	MOSI
-
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 
 // same as the default SPI port
-#define	_DSPI0_BASE			((uint32_t) &SPI2CON)
+#define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_FAULT_VECTOR
 #define	_DSPI0_RX_IRQ		_SPI2_RX_VECTOR
 #define	_DSPI0_TX_IRQ		_SPI2_TX_VECTOR
@@ -414,7 +395,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 
 
 // 2nd SPI
-#define	_DSPI1_BASE			((uint32_t) &SPI1CON)
+#define	_DSPI1_BASE			_SPI1_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI1_FAULT_VECTOR
 #define	_DSPI1_RX_IRQ		_SPI1_RX_VECTOR
 #define	_DSPI1_TX_IRQ		_SPI1_TX_VECTOR
@@ -429,7 +410,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DSPI1_MOSI_PIN		35		        // RA4  SDO1    RPA4R = SDO1 = 3
 
 // SD Card
-#define	_DSPI2_BASE			((uint32_t) &SPI3CON)
+#define	_DSPI2_BASE			_SPI3_BASE_ADDRESS
 #define	_DSPI2_ERR_IRQ		_SPI3_FAULT_VECTOR
 #define	_DSPI2_RX_IRQ		_SPI3_RX_VECTOR
 #define	_DSPI2_TX_IRQ		_SPI3_TX_VECTOR
@@ -444,7 +425,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DSPI2_MOSI_PIN		54		    // RA4  SDO1    RPA4R = SDO1 = 3
 
 // this is the MRF24
-#define	_DSPI3_BASE			((uint32_t) &SPI4CON)
+#define	_DSPI3_BASE			_SPI4_BASE_ADDRESS
 #define	_DSPI3_ERR_IRQ		_SPI4_FAULT_VECTOR
 #define	_DSPI3_RX_IRQ		_SPI4_RX_VECTOR
 #define	_DSPI3_TX_IRQ		_SPI4_TX_VECTOR
@@ -466,7 +447,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 /* The standard I2C port uses I2C4 (SCL4/SDA4). These come to pins
 ** A4/A5 pins 18/19 on the analog connector.
 */
-#define	_TWI_BASE		((uint32_t) &I2C4CON)
+#define	_TWI_BASE		_I2C4_BASE_ADDRESS
 #define	_TWI_BUS_IRQ	_I2C4_BUS_VECTOR
 #define	_TWI_SLV_IRQ	_I2C4_SLAVE_VECTOR
 #define	_TWI_MST_IRQ	_I2C4_MASTER_VECTOR
@@ -479,7 +460,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 **		DTWI0 is SDA2/SCL2 on A4/A5 pins 18/19 (see above comment).
 */
 
-#define	_DTWI0_BASE		((uint32_t) &I2C4CON)
+#define	_DTWI0_BASE		_I2C4_BASE_ADDRESS
 #define	_DTWI0_BUS_IRQ	_I2C4_BUS_VECTOR
 #define	_DTWI0_VECTOR	_I2C4_BUS_VECTOR
 #define	_DTWI0_IPL_ISR	IPL3SRS 
@@ -488,7 +469,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DTWI0_SCL_PIN  19 
 #define _DTWI0_SDA_PIN  18
 
-#define	_DTWI1_BASE		((uint32_t) &I2C2CON)
+#define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
 #define	_DTWI1_BUS_IRQ	_I2C2_BUS_VECTOR
 #define	_DTWI1_VECTOR	_I2C2_BUS_VECTOR
 #define	_DTWI1_IPL_ISR	IPL3SRS 

--- a/pic32/variants/openbci/Board_Defs.h
+++ b/pic32/variants/openbci/Board_Defs.h
@@ -317,25 +317,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The default SPI port uses SPI1.
-*/
-#define	_SPI_BASE		_SPI1_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI1_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI1_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI1_TX_IRQ
-#define	_SPI_VECTOR		_SPI_1_VECTOR
-#define	_SPI_IPL_ISR	_SPI1_IPL_ISR
-#define	_SPI_IPL		_SPI1_IPL_IPC
-#define	_SPI_SPL		_SPI1_SPL_IPC
-
-/* SPI pin declarations
-*/
-#define _SPI_MISO_IN	PPS_IN_SDI1
-#define	_SPI_MISO_PIN	MISO
-#define _SPI_MOSI_OUT	PPS_OUT_SDO1
-#define	_SPI_MOSI_PIN	MOSI
-
-/* SPI1 
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 // RA0  CS1     PGED3/VREF+/CVREF+/AN0/C3INC/RPA0/CTED1/PMD7/RA0 
 // RA4  SDO1    RPA4R = SDO1 = 3    

--- a/pic32/variants/picadillo_35t/Board_Defs.h
+++ b/pic32/variants/picadillo_35t/Board_Defs.h
@@ -216,18 +216,7 @@ extern const uint8_t    digital_pin_to_analog_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI4.  This is the 6 pin SPI header.
-*/
-#define	_SPI_BASE		_SPI4_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI4_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI4_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI4_TX_IRQ
-#define	_SPI_VECTOR		_SPI_4_VECTOR
-#define _SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 
 // DSPI0 talks to the SD card direct (SPI2)

--- a/pic32/variants/uC32/Board_Defs.h
+++ b/pic32/variants/uC32/Board_Defs.h
@@ -296,18 +296,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ

--- a/pic32/variants/uC32_Pmod_Shield/Board_Defs.h
+++ b/pic32/variants/uC32_Pmod_Shield/Board_Defs.h
@@ -300,18 +300,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /*					SPI Port Declarations						*/
 /* ------------------------------------------------------------ */
 
-/* The standard SPI port uses SPI2.
-*/
-#define	_SPI_BASE		_SPI2_BASE_ADDRESS
-#define _SPI_ERR_IRQ	_SPI2_ERR_IRQ
-#define	_SPI_RX_IRQ		_SPI2_RX_IRQ
-#define	_SPI_TX_IRQ		_SPI2_TX_IRQ
-#define	_SPI_VECTOR		_SPI_2_VECTOR
-#define _SPI_IPL_ISR	IPL3SOFT
-#define	_SPI_IPL		3
-#define	_SPI_SPL		0
-
-/* The Digilent DSPI library uses these ports.
+/* The Digilent DSPI and standard SPI libraries uses these ports.
 */
 #define	_DSPI0_BASE			_SPI2_BASE_ADDRESS
 #define	_DSPI0_ERR_IRQ		_SPI2_ERR_IRQ


### PR DESCRIPTION
Removed all SPI definitions from variant files (we now use DSPI defines in SPI.cpp)
Updated #ifdef in several files to use __PIC32_PPS__ rather than separate CPU defines
Replaced bare register names in variant defines with _BASE_ADDRESS_ defines from compiler .h files now that they are there.