### PR TITLE
fix SPI to correct DSPI0 and -1 as task ID

### DIFF
--- a/pic32/cores/pic32/task_manager.c
+++ b/pic32/cores/pic32/task_manager.c
@@ -185,12 +185,11 @@ createTask(taskFunc task, unsigned long period, unsigned short state, void * var
 
 void
 destroyTask(int id) {
-//	int				itask;
 	unsigned int	st;
 
 	/* Remove the specified task from the table.
 	*/
-	if (id < NUM_TASKS) {
+	if (0 <= id && id < NUM_TASKS) {
 		rgtaskTable[id].pfnTask = 0;
 		rgtaskTable[id].tmsPeriod = 0;
 		rgtaskTable[id].stTask = 0;
@@ -259,7 +258,7 @@ getTaskId(taskFunc task) {
 void
 startTaskAt(int id, unsigned long tms, unsigned short st) {
 
-	if ((id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
+	if ((0 <= id && id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
 		rgtaskTable[id].tmsNext = tms;
 		rgtaskTable[id].stTask = st;
 		_updateTaskEvent(millis());
@@ -285,7 +284,7 @@ startTaskAt(int id, unsigned long tms, unsigned short st) {
 unsigned long
 getTaskNextExec(int id) {
 
-	if ((id < NUM_TASKS) &&
+	if ((0 <= id && id < NUM_TASKS) &&
 		(rgtaskTable[id].pfnTask != 0) && 
 		(rgtaskTable[id].stTask != TASK_DISABLE)) {
 		return rgtaskTable[id].tmsNext;
@@ -321,7 +320,7 @@ void
 setTaskState(int id, unsigned short st) {
 	unsigned long tms;
 
-	if ((id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
+	if ((0 <= id && id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
 		rgtaskTable[id].stTask = st;
 		if (rgtaskTable[id].stTask != TASK_DISABLE) {
 			/* Update when the task should next become active.
@@ -352,7 +351,7 @@ setTaskState(int id, unsigned short st) {
 unsigned short
 getTaskState(int id) {
 
-	if ((id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
+	if ((0 <= id && id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
 		return rgtaskTable[id].stTask;
 	}
 
@@ -381,7 +380,7 @@ void
 setTaskPeriod(int id, unsigned long tmsSet)	{
 	unsigned long tmsCur;
 
-	if ((id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
+	if ((0 <= id && id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
 		/* Set the new scheculing period for this task.
 		*/
 		rgtaskTable[id].tmsPeriod = tmsSet;
@@ -417,7 +416,7 @@ setTaskPeriod(int id, unsigned long tmsSet)	{
 unsigned long
 getTaskPeriod(int id) {
 
-	if ((id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
+	if ((0 <= id && id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
 		return rgtaskTable[id].tmsPeriod;
 	}
 
@@ -444,7 +443,7 @@ getTaskPeriod(int id) {
 void
 setTaskVar(int id, void * var) {
 
-	if ((id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
+	if ((0 <= id && id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
 		rgtaskTable[id].varTask = var;
 	}
 
@@ -469,7 +468,7 @@ setTaskVar(int id, void * var) {
 void *
 getTaskVar(int id) {
 
-	if ((id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
+	if ((0 <= id && id < NUM_TASKS) && (rgtaskTable[id].pfnTask != 0)) {
 		return rgtaskTable[id].varTask;
 	}
 

--- a/pic32/variants/Cerebot_32MX7/Board_Defs.h
+++ b/pic32/variants/Cerebot_32MX7/Board_Defs.h
@@ -165,13 +165,13 @@ static const uint8_t MISO = 42;		// PIC32 SDI4
 static const uint8_t SCK  = 43;		// PIC32 SCK4
 
 /* The Digilent DSPI library uses these ports.
-**		DSPI0	connector JD
+**		DSPI0	connector JF
 **		DSPI1	connector JE
-**		DSPI2	connector JF
+**		DSPI2	connector JD
 */
-#define	PIN_DSPI0_SS	24
+#define	PIN_DSPI0_SS	40
 #define	PIN_DSPI1_SS	32
-#define	PIN_DSPI2_SS	40
+#define	PIN_DSPI2_SS	24
 
 /* ------------------------------------------------------------ */
 /*					Analog Pins									*/
@@ -311,38 +311,36 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /* ------------------------------------------------------------ */
 
 /* The Digilent DSPI and standard SPI libraries uses these ports.
-**		DSPI0	connector JD
+**		DSPI0	connector JF
 **		DSPI1	connector JE
-**		DSPI2	connector JF
+**		DSPI2	connector JD
 */
-#define	_DSPI0_BASE			_SPI1_BASE_ADDRESS
-#define	_DSPI0_ERR_IRQ		_SPI1_ERR_IRQ
-#define	_DSPI0_RX_IRQ		_SPI1_RX_IRQ
-#define	_DSPI0_TX_IRQ		_SPI1_TX_IRQ
-#define	_DSPI0_VECTOR		_SPI_1_VECTOR
-#define	_DSPI0_IPL_ISR		IPL3SOFT
-#define	_DSPI0_IPL			3
-#define	_DSPI0_SPL			0
+#define	_DSPI0_BASE	        _SPI4_BASE_ADDRESS 		
+#define	_DSPI0_ERR_IRQ		_SPI4_ERR_IRQ      
+#define	_DSPI0_RX_IRQ		_SPI4_RX_IRQ       
+#define	_DSPI0_TX_IRQ		_SPI4_TX_IRQ       
+#define	_DSPI0_VECTOR		_SPI_4_VECTOR      
+#define	_DSPI0_IPL_ISR		_SPI4_IPL_ISR      
+#define	_DSPI0_IPL			_SPI4_IPL_IPC      
+#define	_DSPI0_SPL			_SPI4_SPL_IPC      
 
-//#define	_SPI3_ERR_IRQ	_SPI1A_ERR_IRQ	//this definition is missing from
-										// the Microchip header file.
 #define	_DSPI1_BASE			_SPI3_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI3_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI3_RX_IRQ
 #define	_DSPI1_TX_IRQ		_SPI3_TX_IRQ
 #define	_DSPI1_VECTOR		_SPI_3_VECTOR
-#define	_DSPI1_IPL_ISR		IPL3SOFT
-#define	_DSPI1_IPL			3
-#define	_DSPI1_SPL			0
+#define	_DSPI1_IPL_ISR		_SPI3_IPL_ISR
+#define	_DSPI1_IPL			_SPI3_IPL_IPC
+#define	_DSPI1_SPL			_SPI3_SPL_IPC
 
-#define	_DSPI2_BASE			_SPI4_BASE_ADDRESS
-#define	_DSPI2_ERR_IRQ		_SPI4_ERR_IRQ
-#define	_DSPI2_RX_IRQ		_SPI4_RX_IRQ
-#define	_DSPI2_TX_IRQ		_SPI4_TX_IRQ
-#define	_DSPI2_VECTOR		_SPI_4_VECTOR
-#define	_DSPI2_IPL_ISR		IPL3SOFT
-#define	_DSPI2_IPL			3
-#define	_DSPI2_SPL			0
+#define	_DSPI2_BASE			_SPI1_BASE_ADDRESS
+#define	_DSPI2_ERR_IRQ		_SPI1_ERR_IRQ
+#define	_DSPI2_RX_IRQ		_SPI1_RX_IRQ
+#define	_DSPI2_TX_IRQ		_SPI1_TX_IRQ
+#define	_DSPI2_VECTOR		_SPI_1_VECTOR
+#define	_DSPI2_IPL_ISR		_SPI1_IPL_ISR
+#define	_DSPI2_IPL			_SPI1_IPL_IPC
+#define	_DSPI2_SPL			_SPI1_SPL_IPC
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -431,8 +429,8 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	prtSCK				IOPORT_D
 #define	bnSCK				BIT_10
 
-#define DefineSDSPI(var) DSPI0 var
-#define DefineDSDVOL(vol, spi) DSDVOL vol(spi, 26)     // Create an DSDVOL object
+#define DefineSDSPI(var) DSPI2 var                      // JD
+#define DefineDSDVOL(vol, spi) DSDVOL vol(spi, 26)      // Create an DSDVOL object
 
 /* ------------------------------------------------------------ */
 /*					Defines for the On Board Mac/Phy            */

--- a/pic32/variants/Cerebot_MX7cK/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX7cK/Board_Defs.h
@@ -166,13 +166,13 @@ static const uint8_t MISO = 42;		// PIC32 SDI4
 static const uint8_t SCK  = 43;		// PIC32 SCK4
 
 /* The Digilent DSPI library uses these ports.
-**		DSPI0	connector JD
+**		DSPI0	connector JF
 **		DSPI1	connector JE
-**		DSPI2	connector JF
+**		DSPI2	connector JD
 */
-#define	PIN_DSPI0_SS	24
+#define	PIN_DSPI0_SS	40
 #define	PIN_DSPI1_SS	32
-#define	PIN_DSPI2_SS	40
+#define	PIN_DSPI2_SS	24
 
 /* ------------------------------------------------------------ */
 /*					Analog Pins									*/
@@ -312,21 +312,19 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 /* ------------------------------------------------------------ */
 
 /* The Digilent DSPI and standard SPI libraries uses these ports.
-**		DSPI0	connector JD
+**		DSPI0	connector JF
 **		DSPI1	connector JE
-**		DSPI2	connector JF
+**		DSPI2	connector JD
 */
-#define	_DSPI0_BASE			_SPI1_BASE_ADDRESS
-#define	_DSPI0_ERR_IRQ		_SPI1_ERR_IRQ
-#define	_DSPI0_RX_IRQ		_SPI1_RX_IRQ
-#define	_DSPI0_TX_IRQ		_SPI1_TX_IRQ
-#define	_DSPI0_VECTOR		_SPI_1_VECTOR
-#define	_DSPI0_IPL_ISR		_SPI1_IPL_ISR
-#define	_DSPI0_IPL			_SPI1_IPL_IPC
-#define	_DSPI0_SPL			_SPI1_SPL_IPC
+#define	_DSPI0_BASE	        _SPI4_BASE_ADDRESS 		
+#define	_DSPI0_ERR_IRQ		_SPI4_ERR_IRQ      
+#define	_DSPI0_RX_IRQ		_SPI4_RX_IRQ       
+#define	_DSPI0_TX_IRQ		_SPI4_TX_IRQ       
+#define	_DSPI0_VECTOR		_SPI_4_VECTOR      
+#define	_DSPI0_IPL_ISR		_SPI4_IPL_ISR      
+#define	_DSPI0_IPL			_SPI4_IPL_IPC      
+#define	_DSPI0_SPL			_SPI4_SPL_IPC      
 
-//#define	_SPI3_ERR_IRQ	_SPI1A_ERR_IRQ	//this definition is missing from
-										// the Microchip header file.
 #define	_DSPI1_BASE			_SPI3_BASE_ADDRESS
 #define	_DSPI1_ERR_IRQ		_SPI3_ERR_IRQ
 #define	_DSPI1_RX_IRQ		_SPI3_RX_IRQ
@@ -336,14 +334,14 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	_DSPI1_IPL			_SPI3_IPL_IPC
 #define	_DSPI1_SPL			_SPI3_SPL_IPC
 
-#define	_DSPI2_BASE			_SPI4_BASE_ADDRESS
-#define	_DSPI2_ERR_IRQ		_SPI4_ERR_IRQ
-#define	_DSPI2_RX_IRQ		_SPI4_RX_IRQ
-#define	_DSPI2_TX_IRQ		_SPI4_TX_IRQ
-#define	_DSPI2_VECTOR		_SPI_4_VECTOR
-#define	_DSPI2_IPL_ISR		_SPI4_IPL_ISR
-#define	_DSPI2_IPL			_SPI4_IPL_IPC
-#define	_DSPI2_SPL			_SPI4_SPL_IPC
+#define	_DSPI2_BASE			_SPI1_BASE_ADDRESS
+#define	_DSPI2_ERR_IRQ		_SPI1_ERR_IRQ
+#define	_DSPI2_RX_IRQ		_SPI1_RX_IRQ
+#define	_DSPI2_TX_IRQ		_SPI1_TX_IRQ
+#define	_DSPI2_VECTOR		_SPI_1_VECTOR
+#define	_DSPI2_IPL_ISR		_SPI1_IPL_ISR
+#define	_DSPI2_IPL			_SPI1_IPL_IPC
+#define	_DSPI2_SPL			_SPI1_SPL_IPC
 
 /* ------------------------------------------------------------ */
 /*					I2C Port Declarations						*/
@@ -430,8 +428,8 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define	prtSCK				IOPORT_D
 #define	bnSCK				BIT_10
 
-#define DefineSDSPI(var) DSPI0 var
-#define DefineDSDVOL(vol, spi) DSDVOL vol(spi, 26)     // Create an DSDVOL object
+#define DefineSDSPI(var) DSPI2 var                      // JD
+#define DefineDSDVOL(vol, spi) DSDVOL vol(spi, 26)      // Create an DSDVOL object
 
 /* ------------------------------------------------------------ */
 /*					Defines for the On Board Mac/Phy            */


### PR DESCRIPTION
SPI was rewritten to assume DSPI0, which was not true. Updated the Digilent MX7s to put the Arduino SPI on DSPI0. The task manager was written with id parameter taken as an int, however checks assumed unsigned; made comparisons assuming an int. 