### PR TITLE
initial compile recipe fix

### DIFF
--- a/pic32/platform.txt
+++ b/pic32/platform.txt
@@ -25,12 +25,14 @@ compiler.c.cmd=pic32-gcc
 # Use a high -Gnum for devices that have less than 64K of data memory
 # For -G1024, objects 1024 bytes or smaller will be accessed by
 # gp-relative addressing
-compiler.c.flags=-c -g -O2 {compiler.warning_flags} -mno-smart-io -ffunction-sections -fdata-sections  -mdebugger -Wcast-align -fno-short-double -ftoplevel-reorder -MMD
+#compiler.c.flags=-c -g -O2 {compiler.warning_flags} -mno-smart-io -ffunction-sections -fdata-sections  -mdebugger -Wcast-align -fno-short-double -ftoplevel-reorder -MMD
+compiler.c.flags=-c -g -O2 {compiler.warning_flags}  -DARDUINO_ARCH_{build.arch} -mno-smart-io -ffunction-sections -fdata-sections  -mdebugger -Wcast-align -fno-short-double -ftoplevel-reorder -MMD
 compiler.c.elf.flags={compiler.warning_flags} -Os -Wl,--save-gld={build.path}/sketch.ld,-Map={build.path}/sketch.map,--gc-sections -mdebugger -mno-peripheral-libs -nostartfiles
 compiler.c.elf.cmd=pic32-g++
 compiler.S.flags=-c -g1 -O2 -Wa,--gdwarf-2
 compiler.cpp.cmd=pic32-g++
-compiler.cpp.flags=-c -g -O2 {compiler.warning_flags} -mno-smart-io -fno-exceptions -ffunction-sections -fdata-sections -mdebugger -Wcast-align -fno-short-double -ftoplevel-reorder -MMD
+#compiler.cpp.flags=-c -g -O2 {compiler.warning_flags} -mno-smart-io -fno-exceptions -ffunction-sections -fdata-sections -mdebugger -Wcast-align -fno-short-double -ftoplevel-reorder -MMD
+compiler.cpp.flags={compiler.c.flags} -fno-exceptions
 compiler.ar.cmd=pic32-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=pic32-objcopy


### PR DESCRIPTION
Fixes the problem where compiler line definitions are missing.
Also is optimized by reuse of common cflags.

Briefly: ARDUINO_ARCH_{build.arch} is not defined for the compile of the .ino file, which causes nasty problems when you want to have a sketch that can compile on multiple platforms, or if the sketch has inline-c/c++ added by includes that depend on it to be defined.

For an example sketch that will fail without this patch see: https://github.com/felis/UHS30/blob/master/libraries/USB_HOST_SHIELD/examples/board_qc/board_qc.ino#L40

The example will fail in the actual libraries as well, since they are all using header-style inlined C and C++.
