### PR TITLE
Added extra overloading for DSPI transfer function

### DIFF
--- a/pic32/libraries/DSPI/DSPI.h
+++ b/pic32/libraries/DSPI/DSPI.h
@@ -175,7 +175,9 @@ void		setTransferSize(uint8_t txsize);
 */
 void		setSelect(uint8_t sel) { digitalWrite(pinSS, sel); };
 uint32_t	transfer(uint32_t bVal);
+uint16_t	transfer(uint16_t bVal) { return((uint16_t) transfer((uint32_t) bVal)); }
 uint8_t	    transfer(uint8_t bVal) { return((uint8_t) transfer((uint32_t) bVal)); }
+int 	    transfer(int bVal) { return((int) transfer((uint32_t) bVal)); }
 void		transfer(uint16_t cbReq, uint8_t * pbSnd, uint8_t * pbRcv);
 void		transfer(uint16_t cbReq, uint8_t * pbSnd);
 void		transfer(uint16_t cbReq, uint8_t bPad, uint8_t * pbRcv);


### PR DESCRIPTION
This fixes problems with the new compiler unable to work out which transfer function to use when:

* Using a numeric literal
* Using a uint16_t value.

