### PR TITLE
Implemented software-based setBitOrder()

### DIFF
--- a/pic32/libraries/SPI/SPI.cpp
+++ b/pic32/libraries/SPI/SPI.cpp
@@ -68,10 +68,12 @@ SPIClass::SPIClass(uint32_t base, int pinMI, int pinMO, ppsFunctionType ppsMI, p
     pinMOSI = pinMO;
     ppsMISO = ppsMI;
     ppsMOSI = ppsMO;
+    softBitOrder = MSBFIRST;
 }
 #else
 SPIClass::SPIClass(uint32_t base) {
     pspi = (p32_spi *)base;
+    softBitOrder = MSBFIRST;
 }
 #endif
 


### PR DESCRIPTION
This sets a variable for the desired bit order, and if that is LSBFIRST the transfer function manually reverses the order of the bits to be sent, and then also reverses the order of bits received. All other values of the variable leave the data alone.

This emulates the AVR's ability to send data through SPI least-significant bit first.