### PR TITLE
Added pin mappings for Lenny in SD card hard coded pin defs file

### DIFF
--- a/pic32/libraries/Firmata/Boards.h
+++ b/pic32/libraries/Firmata/Boards.h
@@ -396,6 +396,23 @@ writePort(port, value, bitmask):  Write an 8 bit port.
 #define PIN_TO_PWM(p)           (p)
 #define PIN_TO_SERVO(p)         (p)
 
+// Pic32 chipKIT Lenny
+#elif defined(_BOARD_LENNY_)
+#define TOTAL_ANALOG_PINS       6
+#define TOTAL_PINS              NUM_DIGITAL_PINS 
+#define MAX_SERVOS              NUM_DIGITAL_PINS
+#define VERSION_BLINK_PIN       PIN_LED1
+#define IS_PIN_DIGITAL(p)       ((p < 14) || (p > 19))
+#define IS_PIN_ANALOG(p)        ((p >= 14) && (p <= 19))
+#define IS_PIN_PWM(p)           IS_PIN_DIGITAL(p)
+#define IS_PIN_SERVO(p)         IS_PIN_DIGITAL(p)
+#define IS_PIN_I2C(p)           ((p) == 18 || (p) == 19)
+#define IS_PIN_SPI(p)           ((p) == SS || (p) == MOSI || (p) == MISO || (p) == SCK)
+#define PIN_TO_DIGITAL(p)       (p)
+#define PIN_TO_ANALOG(p)        (p)
+#define PIN_TO_PWM(p)           (p)
+#define PIN_TO_SERVO(p)         (p)
+
 
 // Pic32 chipKIT UNO32
 #elif defined(_BOARD_UNO_) && defined(__PIC32)  // NOTE: no _BOARD_UNO32_ to use

--- a/pic32/libraries/SD/utility/Sd2PinMap.h
+++ b/pic32/libraries/SD/utility/Sd2PinMap.h
@@ -149,6 +149,23 @@
 	#define prtSCK				IOPORT_G
 	#define bnSCK				BIT_6
 	#define SD_SCK_PPS()        RPG6R  = 0b0000    // Bit Banging SPI, set as GPIO
+#elif defined(_BOARD_LENNY_)
+
+	// Digital pin 25
+	#define prtSDO				IOPORT_B
+	#define	bnSDO				BIT_13
+	#define SD_SDO_PPS()        RPB13R   = 0b0000    // Bit Banging SPI, set as GPIO
+
+	// Digital pin 35
+	#define prtSDI				IOPORT_B
+	#define bnSDI				BIT_1
+	#define SD_SDI_PPS()                            // Bit Banging SPI, leave as nothing
+
+	// Digital pin 16
+	#define prtSCK				IOPORT_B
+	#define bnSCK				BIT_14
+	#define SD_SCK_PPS()        RPB14R  = 0b0000    // Bit Banging SPI, set as GPIO
+
 
 #elif defined(__PIC32_PPS__)
     #error Boards with PPS must be specifically defined


### PR DESCRIPTION
This hard coded stuff is pure evil. It should be removed once and for all, and also hardware SPI implemented in the SD library. Until then, here's the bit-banging pin definitions for Lenny.