### PR TITLE
Fixed USBSerial::write packet size in HardwareSerial.cpp and step_delay initialization and usage in Stepper.cpp

### DIFF
--- a/pic32/cores/pic32/HardwareSerial.cpp
+++ b/pic32/cores/pic32/HardwareSerial.cpp
@@ -919,10 +919,6 @@ void USBSerial::flush()
 	// occurs after reading the value of rx_buffer_head but before writing
 	// the value to rx_buffer_tail; the previous value of rx_buffer_head
 	// may be written to rx_buffer_tail, making it appear as if the buffer
-	// don't reverse this or there may be problems if the RX interrupt
-	// occurs after reading the value of rx_buffer_head but before writing
-	// the value to rx_buffer_tail; the previous value of rx_buffer_head
-	// may be written to rx_buffer_tail, making it appear as if the buffer
 	// were full, not empty.
 	_rx_buffer->head	=	_rx_buffer->tail;
 }
@@ -957,14 +953,14 @@ void USBSerial::detachInterrupt() {
 size_t USBSerial::write(const uint8_t *buffer, size_t size)
 {
     TXOn();
-	if (size < kMaxUSBxmitPkt)
+	if (size <= kMaxUSBxmitPkt)
 	{
 		//*	it will fit in one transmit packet
 		cdcacm_print(buffer, size);
 	}
 	else
 	{
-	//*	we can only transmit a maxium of 64 bytes at a time, break it up into 64 byte packets
+	//*	we can only transmit a maxium of 63 bytes at a time, break it up into 63 byte packets
 	unsigned char	usbBuffer[kMaxUSBxmitPkt + 2];
 	unsigned short	ii;
 	size_t 			packetSize;
@@ -973,7 +969,7 @@ size_t USBSerial::write(const uint8_t *buffer, size_t size)
 		for (ii=0; ii<size; ii++)
 		{
 			usbBuffer[packetSize++]	=	buffer[ii];
-			if (packetSize >= kMaxUSBxmitPkt)
+			if (packetSize > kMaxUSBxmitPkt)
 			{
 				cdcacm_print(usbBuffer, packetSize);
 				packetSize	=	0;

--- a/pic32/libraries/Stepper/Stepper.cpp
+++ b/pic32/libraries/Stepper/Stepper.cpp
@@ -56,6 +56,7 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2)
 {
   this->step_number = 0;      // which step the motor is on
   this->speed = 0;        // the motor speed, in revolutions per minute
+  this->step_delay = -1;  // step delay defaulted to max (minium rpms)
   this->direction = 0;      // motor direction
   this->last_step_time = 0;    // time stamp in ms of the last step taken
   this->number_of_steps = number_of_steps;    // total number of steps for this motor
@@ -86,6 +87,7 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2, int moto
 {
   this->step_number = 0;      // which step the motor is on
   this->speed = 0;        // the motor speed, in revolutions per minute
+  this->step_delay = -1;  // step delay defaulted to max (minimum rpms)
   this->direction = 0;      // motor direction
   this->last_step_time = 0;    // time stamp in ms of the last step taken
   this->number_of_steps = number_of_steps;    // total number of steps for this motor
@@ -112,7 +114,13 @@ Stepper::Stepper(int number_of_steps, int motor_pin_1, int motor_pin_2, int moto
 */
 void Stepper::setSpeed(long whatSpeed)
 {
-  this->step_delay = 60L * 1000L / this->number_of_steps / whatSpeed;
+  // avoid divide by 0
+  if (whatSpeed > 0) {
+    this->step_delay = 60L * 1000L / this->number_of_steps / whatSpeed;
+  } else {
+    // divide by 0 attempted, set speed to minimum rpms
+    this->step_delay = -1; 
+  }
 }
 
 /*


### PR DESCRIPTION
1) Removed Duplicate Copy and Paste from Flush Comment
2) Updated comment to "we can only transmit a maxium of 63 bytes at a time, break it up into 63 byte packets" from "we can only transmit a maxium of 64 bytes at a time, break it up into 64 byte packets"

The following changes are because the current code would seemingly only transmit 62byte packets. 
3) Changed if (size < kMaxUSBxmitPkt) to if (size <= kMaxUSBxmitPkt)
4) if (packetSize >= kMaxUSBxmitPkt) to if (packetSize > kMaxUSBxmitPkt)