### PR TITLE
SoftwareSerial with simplex classes

### DIFF
--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -989,7 +989,7 @@ void SoftwareSerialRx::end()
  * If this RX pin is on a CN, then read from the RX buffer. If not (it's just a normal
  * GPIO pin) then block and read a byte from the RX pin.
  */ 
-int SoftwareSerial::read(void) { return SoftwareSerialRx::read(); }
+//int SoftwareSerial::read(void) { return SoftwareSerialRx::read(); }
 //int SoftwareSerialTx::read(void) { return 0; }
 int SoftwareSerialRx::read(void)
 {
@@ -1012,7 +1012,7 @@ int SoftwareSerialRx::read(void)
  * in on the RX pin. If it does, then it will return 1. If it does not (in that time) then
  * it will return 0.
  */
-int SoftwareSerial::available(uint32_t timeout_ms) { return SoftwareSerialRx::available(timeout_ms); }
+//int SoftwareSerial::available(uint32_t timeout_ms) { return SoftwareSerialRx::available(timeout_ms); }
 //int SoftwareSerialTx::available(uint32_t timeout_ms) { return 0; }
 int SoftwareSerialRx::available(uint32_t timeout_ms) 
 {
@@ -1044,7 +1044,7 @@ int SoftwareSerialRx::available(uint32_t timeout_ms)
  * read so that it goes and calls read() to read the byte (even if there is none
  * currently coming in.)
  */ 
-int SoftwareSerial::available() { return SoftwareSerialRx::available(); }
+//int SoftwareSerial::available() { return SoftwareSerialRx::available(); }
 //int SoftwareSerialTx::available() { return 0; }
 int SoftwareSerialRx::available()
 {
@@ -1064,7 +1064,7 @@ int SoftwareSerialRx::available()
  * Interrupts are disabled for the entire time the byte is being sent out.
  * Since we always send one byte, we always return a 1.
  */ 
-size_t SoftwareSerial::write(uint8_t b) { return SoftwareSerialTx::write(b); }
+//size_t SoftwareSerial::write(uint8_t b) { return SoftwareSerialTx::write(b); }
 //size_t SoftwareSerialRx::write(uint8_t b) { return 0; }
 size_t SoftwareSerialTx::write(uint8_t b)
 {
@@ -1250,7 +1250,7 @@ DEBUG0_LOW
  * Since we do not use buffered transmit in this library, this function
  * doesn't have much to do.
  */
-void SoftwareSerial::flush() { return SoftwareSerialTx::flush(); }
+//void SoftwareSerial::flush() { return SoftwareSerialTx::flush(); }
 void SoftwareSerialTx::flush() {}
 //void SoftwareSerialRx::flush() {}
 
@@ -1258,7 +1258,7 @@ void SoftwareSerialTx::flush() {}
  * If this RX pin is a CN pin (and thus has an RX buffer), peek at the next byte in the buffer and
  * return it. If this is not a CN pin, then return an error value of -1.
  */ 
-int SoftwareSerial::peek() { return SoftwareSerialRx::peek(); }
+//int SoftwareSerial::peek() { return SoftwareSerialRx::peek(); }
 //int SoftwareSerialTx::peek() { return -1; }
 int SoftwareSerialRx::peek()
 {

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -643,38 +643,32 @@ bool SoftwareSerialRx::stopListening()
     return false;
 }
 
+/*
+ * Start things up on this serial object with the default RX buffer size 
+ * (only applies if this pin is a CN pin)
+ */ 
 void SoftwareSerial::begin(long speed)
 {
     SoftwareSerialRx::begin(speed);
     SoftwareSerialTx::begin(speed);
 }
-
-/*
- * Start things up on this serial object with the default RX buffer size 
- * (only applies if this pin is a CN pin)
- */ 
 void SoftwareSerialTx::begin(long speed)
 {
     begin(speed, TS_BUFSZ);
 }
-
-/*
- * Start things up on this serial object with the default RX buffer size 
- * (only applies if this pin is a CN pin)
- */ 
 void SoftwareSerialRx::begin(long speed)
 {
     begin(speed, TS_BUFSZ);
-}
-void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
-{
-    SoftwareSerialRx::begin(speed, RX_buffer_size);
-    SoftwareSerialTx::begin(speed, RX_buffer_size);
 }
 /*
  * The real begin function. Takes a baud rate (same for RX and TX) and a RX buffer size.
  * RX buffer size is only used if the RX pin is on a Change Notification pin.
  */ 
+void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
+{
+    SoftwareSerialRx::begin(speed, RX_buffer_size);
+    SoftwareSerialTx::begin(speed, RX_buffer_size);
+}
 void SoftwareSerialRx::begin(long speed, uint32_t RX_buffer_size)
 {
     uint8_t     port;
@@ -935,10 +929,6 @@ void SoftwareSerialRx::begin(long speed, uint32_t RX_buffer_size)
     listen();
 }
 
-/*
- * The real begin function. Takes a baud rate (same for RX and TX) and a RX buffer size.
- * RX buffer size is only used if the RX pin is on a Change Notification pin.
- */ 
 void SoftwareSerialTx::begin(long speed, uint32_t RX_buffer_size)
 {
     uint8_t     port;
@@ -970,6 +960,11 @@ void SoftwareSerialTx::begin(long speed, uint32_t RX_buffer_size)
  * We're done with this serial object, so cancel the Change Notification on it's RX
  * pin (if any) and then stop listening on this RX pin.
  */ 
+void SoftwareSerial::end()
+{
+  SoftwareSerialTx::end();
+  SoftwareSerialRx::end();
+}
 void SoftwareSerialTx::end() {}
 void SoftwareSerialRx::end()
 {
@@ -995,7 +990,7 @@ void SoftwareSerialRx::end()
  * GPIO pin) then block and read a byte from the RX pin.
  */ 
 int SoftwareSerial::read(void) { return SoftwareSerialRx::read(); }
-int SoftwareSerialTx::read(void) { return 0; }
+//int SoftwareSerialTx::read(void) { return 0; }
 int SoftwareSerialRx::read(void)
 {
     if (_on_CN_pin) 
@@ -1018,7 +1013,7 @@ int SoftwareSerialRx::read(void)
  * it will return 0.
  */
 int SoftwareSerial::available(uint32_t timeout_ms) { return SoftwareSerialRx::available(timeout_ms); }
-int SoftwareSerialTx::available(uint32_t timeout_ms) { return 0; }
+//int SoftwareSerialTx::available(uint32_t timeout_ms) { return 0; }
 int SoftwareSerialRx::available(uint32_t timeout_ms) 
 {
     uint32_t end_time_ms = millis() + timeout_ms;
@@ -1050,7 +1045,7 @@ int SoftwareSerialRx::available(uint32_t timeout_ms)
  * currently coming in.)
  */ 
 int SoftwareSerial::available() { return SoftwareSerialRx::available(); }
-int SoftwareSerialTx::available() { return 0; }
+//int SoftwareSerialTx::available() { return 0; }
 int SoftwareSerialRx::available()
 {
     if (_on_CN_pin) 
@@ -1070,7 +1065,7 @@ int SoftwareSerialRx::available()
  * Since we always send one byte, we always return a 1.
  */ 
 size_t SoftwareSerial::write(uint8_t b) { return SoftwareSerialTx::write(b); }
-size_t SoftwareSerialRx::write(uint8_t b) { return 0; }
+//size_t SoftwareSerialRx::write(uint8_t b) { return 0; }
 size_t SoftwareSerialTx::write(uint8_t b)
 {
     uint32_t    st;
@@ -1255,18 +1250,16 @@ DEBUG0_LOW
  * Since we do not use buffered transmit in this library, this function
  * doesn't have much to do.
  */
-void SoftwareSerial::flush() { return SoftwareSerialRx::flush(); }
+void SoftwareSerial::flush() { return SoftwareSerialTx::flush(); }
 void SoftwareSerialTx::flush() {}
-void SoftwareSerialRx::flush()
-{
-}
+//void SoftwareSerialRx::flush() {}
 
 /*
  * If this RX pin is a CN pin (and thus has an RX buffer), peek at the next byte in the buffer and
  * return it. If this is not a CN pin, then return an error value of -1.
  */ 
 int SoftwareSerial::peek() { return SoftwareSerialRx::peek(); }
-int SoftwareSerialTx::peek() { return -1; }
+//int SoftwareSerialTx::peek() { return -1; }
 int SoftwareSerialRx::peek()
 {
     if (_on_CN_pin)

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -989,6 +989,8 @@ void SoftwareSerialRx::end()
  * If this RX pin is on a CN, then read from the RX buffer. If not (it's just a normal
  * GPIO pin) then block and read a byte from the RX pin.
  */ 
+int SoftwareSerial::read(void) { return SoftwareSerialRx::read(); }
+int SoftwareSerialTx::read(void) { return 0; }
 int SoftwareSerialRx::read(void)
 {
     if (_on_CN_pin) 
@@ -1010,6 +1012,8 @@ int SoftwareSerialRx::read(void)
  * in on the RX pin. If it does, then it will return 1. If it does not (in that time) then
  * it will return 0.
  */
+int SoftwareSerial::available(uint32_t timeout_ms) { return SoftwareSerialRx::available(timeout_ms); }
+int SoftwareSerialTx::available(uint32_t timeout_ms) { return 0; }
 int SoftwareSerialRx::available(uint32_t timeout_ms) 
 {
     uint32_t end_time_ms = millis() + timeout_ms;
@@ -1040,6 +1044,8 @@ int SoftwareSerialRx::available(uint32_t timeout_ms)
  * read so that it goes and calls read() to read the byte (even if there is none
  * currently coming in.)
  */ 
+int SoftwareSerial::available() { return SoftwareSerialRx::available(); }
+int SoftwareSerialTx::available() { return 0; }
 int SoftwareSerialRx::available()
 {
     if (_on_CN_pin) 
@@ -1058,6 +1064,8 @@ int SoftwareSerialRx::available()
  * Interrupts are disabled for the entire time the byte is being sent out.
  * Since we always send one byte, we always return a 1.
  */ 
+size_t SoftwareSerial::write(uint8_t b) { return SoftwareSerialTx::write(b); }
+size_t SoftwareSerialRx::write(uint8_t b) { return 0; }
 size_t SoftwareSerialTx::write(uint8_t b)
 {
     uint32_t    st;
@@ -1242,12 +1250,16 @@ DEBUG0_LOW
  * Since we do not use buffered transmit in this library, this function
  * doesn't have much to do.
  */
+void SoftwareSerial::flush() { return SoftwareSerialTx::flush(); }
 void SoftwareSerialTx::flush() {}
+void SoftwareSerialRx::flush() {}
 
 /*
  * If this RX pin is a CN pin (and thus has an RX buffer), peek at the next byte in the buffer and
  * return it. If this is not a CN pin, then return an error value of -1.
  */ 
+int SoftwareSerial::peek() { return SoftwareSerialRx::peek(); }
+int SoftwareSerialTx::peek() { return -1; }
 int SoftwareSerialRx::peek()
 {
     if (_on_CN_pin)

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -989,8 +989,6 @@ void SoftwareSerialRx::end()
  * If this RX pin is on a CN, then read from the RX buffer. If not (it's just a normal
  * GPIO pin) then block and read a byte from the RX pin.
  */ 
-int SoftwareSerial::read(void) { return SoftwareSerialRx::read(); }
-int SoftwareSerialTx::read(void) { return 0; }
 int SoftwareSerialRx::read(void)
 {
     if (_on_CN_pin) 
@@ -1012,8 +1010,6 @@ int SoftwareSerialRx::read(void)
  * in on the RX pin. If it does, then it will return 1. If it does not (in that time) then
  * it will return 0.
  */
-int SoftwareSerial::available(uint32_t timeout_ms) { return SoftwareSerialRx::available(timeout_ms); }
-int SoftwareSerialTx::available(uint32_t timeout_ms) { return 0; }
 int SoftwareSerialRx::available(uint32_t timeout_ms) 
 {
     uint32_t end_time_ms = millis() + timeout_ms;
@@ -1044,8 +1040,6 @@ int SoftwareSerialRx::available(uint32_t timeout_ms)
  * read so that it goes and calls read() to read the byte (even if there is none
  * currently coming in.)
  */ 
-int SoftwareSerial::available() { return SoftwareSerialRx::available(); }
-int SoftwareSerialTx::available() { return 0; }
 int SoftwareSerialRx::available()
 {
     if (_on_CN_pin) 
@@ -1064,8 +1058,6 @@ int SoftwareSerialRx::available()
  * Interrupts are disabled for the entire time the byte is being sent out.
  * Since we always send one byte, we always return a 1.
  */ 
-size_t SoftwareSerial::write(uint8_t b) { return SoftwareSerialTx::write(b); }
-size_t SoftwareSerialRx::write(uint8_t b) { return 0; }
 size_t SoftwareSerialTx::write(uint8_t b)
 {
     uint32_t    st;
@@ -1250,16 +1242,12 @@ DEBUG0_LOW
  * Since we do not use buffered transmit in this library, this function
  * doesn't have much to do.
  */
-void SoftwareSerial::flush() { return SoftwareSerialTx::flush(); }
 void SoftwareSerialTx::flush() {}
-void SoftwareSerialRx::flush() {}
 
 /*
  * If this RX pin is a CN pin (and thus has an RX buffer), peek at the next byte in the buffer and
  * return it. If this is not a CN pin, then return an error value of -1.
  */ 
-int SoftwareSerial::peek() { return SoftwareSerialRx::peek(); }
-int SoftwareSerialTx::peek() { return -1; }
 int SoftwareSerialRx::peek()
 {
     if (_on_CN_pin)

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -131,9 +131,9 @@
  * Statics
  ******************************************************************************/
 /// TODO: Is this really needed anymore?
-SoftwareSerial *SoftwareSerial::active_object = NULL;
-bool SoftwareSerial::_CN_ISR_hooked = false;
-SoftwareSerial *SoftwareSerial::CN_list_head = NULL;
+SoftwareSerialRx *SoftwareSerialRx::active_object = NULL;
+bool SoftwareSerialBase::_CN_ISR_hooked = false;
+SoftwareSerialRx *SoftwareSerialRx::CN_list_head = NULL;
 
 /******************************************************************************
  * Definitions
@@ -177,7 +177,13 @@ SoftwareSerial *SoftwareSerial::CN_list_head = NULL;
  * Constructors
  ******************************************************************************/
 
-SoftwareSerial::SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic /* = false */)
+SoftwareSerialTx::SoftwareSerialTx(uint8_t transmitPin)
+{
+    _transmitPin = transmitPin;
+    _baudRate = 0;
+}
+
+SoftwareSerialRx::SoftwareSerialRx(uint8_t receivePin, bool inverted_logic /* = false */)
 {
     // Detect if this pin is on a Change Notification or not and record it's CN number if so
 #if !defined(__PIC32_PPS__)
@@ -195,13 +201,23 @@ SoftwareSerial::SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inv
     }
     _inverted_logic = inverted_logic;
     _receivePin = receivePin;
-    _transmitPin = transmitPin;
     _baudRate = 0;
     _have_start_bit_time = false;
     active_object = this;
 }
 
-SoftwareSerial::~SoftwareSerial()
+SoftwareSerial::SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic /* = false */)
+    : SoftwareSerialRx(receivePin, inverted_logic), SoftwareSerialTx(transmitPin)
+{
+  
+}
+
+SoftwareSerialTx::~SoftwareSerialTx()
+{
+    end();
+}
+
+SoftwareSerialRx::~SoftwareSerialRx()
 {
     end();
 }
@@ -217,7 +233,7 @@ void __attribute__((interrupt)) ChangeNotificationISR()
 {
 DEBUG5_HIGH
     // Call the static function that handles all of the CN logic, pass in the current time
-    SoftwareSerial::handleChangeNotificationISR(readCoreTimer());
+    SoftwareSerialRx::handleChangeNotificationISR(readCoreTimer());
 DEBUG5_LOW
     // Clearing the interrupt flag is handled in the above function for PPC CPUs
 #if !defined(__PIC32_PPS__)
@@ -229,7 +245,7 @@ DEBUG5_LOW
  * Look at what's in the SoftwareSerial object obj, and find out if the RX pin that
  * it points to is set or cleared. Also take into account the _inverted_logic setting.
  */
-bool SoftwareSerial::ReadBit(SoftwareSerial* obj)
+bool SoftwareSerialRx::ReadBit(SoftwareSerialRx* obj)
 {
     bool retval;
     
@@ -256,7 +272,7 @@ DEBUG3_LOW
  * don't end up reading port more than once for a given ISR call.
  * /// TODO: On PPS PIC32, use CNSTAT register to help with this
  */
-bool SoftwareSerial::RXBitHasChanged(SoftwareSerial* obj)
+bool SoftwareSerialRx::RXBitHasChanged(SoftwareSerialRx* obj)
 {
     uint8_t state;
     
@@ -279,13 +295,13 @@ bool SoftwareSerial::RXBitHasChanged(SoftwareSerial* obj)
  * leaving the ISR and coming back in. This allows for more reliable data reception at
  * higher baud rates.
  */
-void SoftwareSerial::handleChangeNotificationISR(uint32_t start_bit_time) 
+void SoftwareSerialRx::handleChangeNotificationISR(uint32_t start_bit_time) 
 {
     int32_t     rx_byte;
     uint32_t    bit_time_core_ticks;
     uint32_t    bit_end_time;
     bool        done = false;
-    SoftwareSerial * serial_obj = SoftwareSerial::CN_list_head;
+    SoftwareSerialRx * serial_obj = SoftwareSerialRx::CN_list_head;
     uint32_t    st;
 
     // To minimize the chance of missing edges at high baud rates, we kill all interrupts
@@ -437,7 +453,7 @@ DEBUG4_LOW
  * array looking for a port pointer match and a pin match. If we find
  * one, then we know that this pin is on a CN, and can return true.
  */
-bool SoftwareSerial::is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask)
+bool SoftwareSerialRx::is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask)
 {
 #if defined(__PIC32_PPS__)
     // All pins are CN pins on PPS PIC32s
@@ -469,7 +485,7 @@ bool SoftwareSerial::is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask)
  * the CN ISR, then this function gets called to read in the byte that just started appearing on the
  * RX pin. It disables interrupts to get accurate timing.
  */ 
-int32_t SoftwareSerial::readByte()
+int32_t SoftwareSerialRx::readByte()
 {    
     int32_t     retval = 0;
     uint32_t    st;
@@ -564,18 +580,18 @@ DEBUG0_LOW
  * If this is the first, then just update the static head pointer.
  * Otherwise, walk through the list, and add this one at the end.
  */
-void SoftwareSerial::addCN(void)
+void SoftwareSerialRx::addCN(void)
 {
-    SoftwareSerial *scan;
+    SoftwareSerialRx *scan;
     
-    if (SoftwareSerial::CN_list_head == NULL)
+    if (SoftwareSerialRx::CN_list_head == NULL)
     {
-        SoftwareSerial::CN_list_head = this;
+        SoftwareSerialRx::CN_list_head = this;
         next_CN = NULL;
     }
     else
     {
-        for (scan = SoftwareSerial::CN_list_head; scan->next_CN; scan = scan->next_CN)
+        for (scan = SoftwareSerialRx::CN_list_head; scan->next_CN; scan = scan->next_CN)
         {
         }
         scan->next_CN = this;
@@ -586,9 +602,22 @@ void SoftwareSerial::addCN(void)
 /*
  * Remove this Software Serial object from the linked list of objects that use Change Notification pins.
  */
-void SoftwareSerial::removeCN(void)
+void SoftwareSerialRx::removeCN(void)
 {
     /// TODO
+    /*
+    SoftwareSerialRx *last = NULL;
+    SoftwareSerialRx *scan = SoftwareSerialRx::CN_list_head;
+
+    for (scan = SoftwareSerialRx::CN_list_head; scan != this && scan != NULL; scan = scan->next_CN)
+    {
+        last = this;
+    }
+    if( last == NULL ) // we are the first on the list
+        SoftwareSerialRx::CN_list_head = next_CN
+    else  // we are in the middle
+        last->next_CN = next_CN;
+    */
 }
 
 
@@ -599,7 +628,8 @@ void SoftwareSerial::removeCN(void)
 /*
  * /// TODO
  */ 
-bool SoftwareSerial::listen()
+// bool SoftwareSerialTx::listen() // The Tx port will never listen
+bool SoftwareSerialRx::listen()
 {
   return false;
 }
@@ -607,25 +637,45 @@ bool SoftwareSerial::listen()
 /*
  * /// TODO
  */ 
-bool SoftwareSerial::stopListening()
+// bool SoftwareSerialRx::stopListening() // Since the Tx port will never listen, no need to ever stop listening.
+bool SoftwareSerialRx::stopListening()
 {
     return false;
+}
+
+void SoftwareSerial::begin(long speed)
+{
+    SoftwareSerialRx::begin(speed);
+    SoftwareSerialTx::begin(speed);
 }
 
 /*
  * Start things up on this serial object with the default RX buffer size 
  * (only applies if this pin is a CN pin)
  */ 
-void SoftwareSerial::begin(long speed)
+void SoftwareSerialTx::begin(long speed)
 {
     begin(speed, TS_BUFSZ);
 }
 
 /*
+ * Start things up on this serial object with the default RX buffer size 
+ * (only applies if this pin is a CN pin)
+ */ 
+void SoftwareSerialRx::begin(long speed)
+{
+    begin(speed, TS_BUFSZ);
+}
+void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
+{
+    SoftwareSerialRx::begin(speed, RX_buffer_size);
+    SoftwareSerialTx::begin(speed, RX_buffer_size);
+}
+/*
  * The real begin function. Takes a baud rate (same for RX and TX) and a RX buffer size.
  * RX buffer size is only used if the RX pin is on a Change Notification pin.
  */ 
-void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
+void SoftwareSerialRx::begin(long speed, uint32_t RX_buffer_size)
 {
     uint8_t     port;
     uint32_t    st;
@@ -642,13 +692,6 @@ void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
     _OneBitTime =  ((F_CPU/2)/_baudRate);
     
     pinMode(_receivePin, INPUT);
-    pinMode(_transmitPin, OUTPUT);
-    digitalWrite(_transmitPin, HIGH);
-
-    // Wait for at least 2 bit times with the TX pin high, so that our
-    // receiver knows this is the normal state of the line.
-    bit_end_time = readCoreTimer() + _OneBitTime * 2;
-    while (readCoreTimer() < bit_end_time);
 
     if ((port = digitalPinToPort(_receivePin)) == NOT_A_PIN) 
     {
@@ -656,14 +699,6 @@ void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
     }
     _rxPort = (p32_ioport *)portRegisters(port);
     _rxBit = digitalPinToBitMask(_receivePin);
-
-    if ((port = digitalPinToPort(_transmitPin)) == NOT_A_PIN) 
-    {
-        return;
-    }
-    _txPort = (p32_ioport *)portRegisters(port);
-    _txBit = digitalPinToBitMask(_transmitPin);
-
 
     // If this is an RX pin on a Change Interrupt pin, turn on the Change Notification interrupt
     /// Note: This will clobber any other library's use of Change Notification interrupt
@@ -729,7 +764,7 @@ void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
         // Record the current state of this change notification pin (clears mismatch too)
         _last_RX_pin_state = ReadBit(this); 
 
-        if (!SoftwareSerial::_CN_ISR_hooked)
+        if (!SoftwareSerialRx::_CN_ISR_hooked)
         {
 #if !defined(__PIC32MZXX__)     // MX parts only have one CN vector
             // Configure the change notification interrupt vector
@@ -893,7 +928,7 @@ void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
             CNCONbits.SIDL  =   0;
 #endif            
             // Mark the ISR as set up so that we don't try to do it again
-            SoftwareSerial::_CN_ISR_hooked = true;
+            SoftwareSerialRx::_CN_ISR_hooked = true;
         }
     }
 
@@ -901,10 +936,42 @@ void SoftwareSerial::begin(long speed, uint32_t RX_buffer_size)
 }
 
 /*
+ * The real begin function. Takes a baud rate (same for RX and TX) and a RX buffer size.
+ * RX buffer size is only used if the RX pin is on a Change Notification pin.
+ */ 
+void SoftwareSerialTx::begin(long speed, uint32_t RX_buffer_size)
+{
+    uint8_t     port;
+    uint32_t    st;
+    int32_t     x;
+    int32_t     s;
+    uint32_t    bit_end_time;
+    
+    _baudRate = speed;
+    _OneBitTime =  ((F_CPU/2)/_baudRate);
+    
+    pinMode(_transmitPin, OUTPUT);
+    digitalWrite(_transmitPin, HIGH);
+
+    // Wait for at least 2 bit times with the TX pin high, so that our
+    // receiver knows this is the normal state of the line.
+    bit_end_time = readCoreTimer() + _OneBitTime * 2;
+    while (readCoreTimer() < bit_end_time);
+
+    if ((port = digitalPinToPort(_transmitPin)) == NOT_A_PIN) 
+    {
+        return;
+    }
+    _txPort = (p32_ioport *)portRegisters(port);
+    _txBit = digitalPinToBitMask(_transmitPin);
+}
+
+/*
  * We're done with this serial object, so cancel the Change Notification on it's RX
  * pin (if any) and then stop listening on this RX pin.
  */ 
-void SoftwareSerial::end()
+void SoftwareSerialTx::end() {}
+void SoftwareSerialRx::end()
 {
     if (_on_CN_pin) {
 #if !defined(__PIC32_PPS__)
@@ -927,7 +994,9 @@ void SoftwareSerial::end()
  * If this RX pin is on a CN, then read from the RX buffer. If not (it's just a normal
  * GPIO pin) then block and read a byte from the RX pin.
  */ 
-int SoftwareSerial::read(void)
+int SoftwareSerial::read(void) { return SoftwareSerialRx::read(); }
+int SoftwareSerialTx::read(void) { return 0; }
+int SoftwareSerialRx::read(void)
 {
     if (_on_CN_pin) 
     {
@@ -948,7 +1017,9 @@ int SoftwareSerial::read(void)
  * in on the RX pin. If it does, then it will return 1. If it does not (in that time) then
  * it will return 0.
  */
-int SoftwareSerial::available(uint32_t timeout_ms) 
+int SoftwareSerial::available(uint32_t timeout_ms) { return SoftwareSerialRx::available(timeout_ms); }
+int SoftwareSerialTx::available(uint32_t timeout_ms) { return 0; }
+int SoftwareSerialRx::available(uint32_t timeout_ms) 
 {
     uint32_t end_time_ms = millis() + timeout_ms;
 
@@ -978,7 +1049,9 @@ int SoftwareSerial::available(uint32_t timeout_ms)
  * read so that it goes and calls read() to read the byte (even if there is none
  * currently coming in.)
  */ 
-int SoftwareSerial::available()
+int SoftwareSerial::available() { return SoftwareSerialRx::available(); }
+int SoftwareSerialTx::available() { return 0; }
+int SoftwareSerialRx::available()
 {
     if (_on_CN_pin) 
     {
@@ -996,7 +1069,9 @@ int SoftwareSerial::available()
  * Interrupts are disabled for the entire time the byte is being sent out.
  * Since we always send one byte, we always return a 1.
  */ 
-size_t SoftwareSerial::write(uint8_t b)
+size_t SoftwareSerial::write(uint8_t b) { return SoftwareSerialTx::write(b); }
+size_t SoftwareSerialRx::write(uint8_t b) { return 0; }
+size_t SoftwareSerialTx::write(uint8_t b)
 {
     uint32_t    st;
     uint32_t    bit_end_time;
@@ -1013,7 +1088,7 @@ DEBUG0_HIGH
 DEBUG0_LOW
         return 0;
     }
-  
+//#ifdef SoftwareSerialSplit
     // If any software serial objects are on CN pins (for RX) then disable the CN interrupts
     // while we are transmitting. We have interrupts disabled anyway, so we can't service
     // any RXing during transmit. And things tend to get confused if we leave the CN on.
@@ -1073,6 +1148,7 @@ DEBUG0_LOW
     }
 
     st = disableInterrupts();
+//#endif  // SoftwareSerialSplit
   
     _txPort->lat.clr = _txBit; // Start bit
 
@@ -1111,10 +1187,11 @@ DEBUG1_HIGH
     bit_end_time = readCoreTimer() + _OneBitTime + EXTRA_TX_BIT_TIME;
     while (readCoreTimer() < bit_end_time);
     
+//#ifdef SoftwareSerialSplit
     restoreInterrupts(st);
 
     // And restore the CN functions when we're done transmitting this byte
-    if(SoftwareSerial::_CN_ISR_hooked == true)
+    if(_CN_ISR_hooked == true)
     {
 #if !defined(__PIC32_PPS__)
         CNCONbits.ON    =   1;
@@ -1170,6 +1247,7 @@ DEBUG1_HIGH
     }
 DEBUG1_LOW
 DEBUG0_LOW    
+//#endif  // SoftwareSerialSplit
     return 1;
 }
 
@@ -1177,7 +1255,9 @@ DEBUG0_LOW
  * Since we do not use buffered transmit in this library, this function
  * doesn't have much to do.
  */
-void SoftwareSerial::flush()
+void SoftwareSerial::flush() { return SoftwareSerialRx::flush(); }
+void SoftwareSerialTx::flush() {}
+void SoftwareSerialRx::flush()
 {
 }
 
@@ -1185,7 +1265,9 @@ void SoftwareSerial::flush()
  * If this RX pin is a CN pin (and thus has an RX buffer), peek at the next byte in the buffer and
  * return it. If this is not a CN pin, then return an error value of -1.
  */ 
-int SoftwareSerial::peek()
+int SoftwareSerial::peek() { return SoftwareSerialRx::peek(); }
+int SoftwareSerialTx::peek() { return -1; }
+int SoftwareSerialRx::peek()
 {
     if (_on_CN_pin)
     {

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -989,8 +989,6 @@ void SoftwareSerialRx::end()
  * If this RX pin is on a CN, then read from the RX buffer. If not (it's just a normal
  * GPIO pin) then block and read a byte from the RX pin.
  */ 
-//int SoftwareSerial::read(void) { return SoftwareSerialRx::read(); }
-//int SoftwareSerialTx::read(void) { return 0; }
 int SoftwareSerialRx::read(void)
 {
     if (_on_CN_pin) 
@@ -1012,8 +1010,6 @@ int SoftwareSerialRx::read(void)
  * in on the RX pin. If it does, then it will return 1. If it does not (in that time) then
  * it will return 0.
  */
-//int SoftwareSerial::available(uint32_t timeout_ms) { return SoftwareSerialRx::available(timeout_ms); }
-//int SoftwareSerialTx::available(uint32_t timeout_ms) { return 0; }
 int SoftwareSerialRx::available(uint32_t timeout_ms) 
 {
     uint32_t end_time_ms = millis() + timeout_ms;
@@ -1044,8 +1040,6 @@ int SoftwareSerialRx::available(uint32_t timeout_ms)
  * read so that it goes and calls read() to read the byte (even if there is none
  * currently coming in.)
  */ 
-//int SoftwareSerial::available() { return SoftwareSerialRx::available(); }
-//int SoftwareSerialTx::available() { return 0; }
 int SoftwareSerialRx::available()
 {
     if (_on_CN_pin) 
@@ -1064,8 +1058,6 @@ int SoftwareSerialRx::available()
  * Interrupts are disabled for the entire time the byte is being sent out.
  * Since we always send one byte, we always return a 1.
  */ 
-//size_t SoftwareSerial::write(uint8_t b) { return SoftwareSerialTx::write(b); }
-//size_t SoftwareSerialRx::write(uint8_t b) { return 0; }
 size_t SoftwareSerialTx::write(uint8_t b)
 {
     uint32_t    st;
@@ -1250,16 +1242,12 @@ DEBUG0_LOW
  * Since we do not use buffered transmit in this library, this function
  * doesn't have much to do.
  */
-//void SoftwareSerial::flush() { return SoftwareSerialTx::flush(); }
 void SoftwareSerialTx::flush() {}
-//void SoftwareSerialRx::flush() {}
 
 /*
  * If this RX pin is a CN pin (and thus has an RX buffer), peek at the next byte in the buffer and
  * return it. If this is not a CN pin, then return an error value of -1.
  */ 
-//int SoftwareSerial::peek() { return SoftwareSerialRx::peek(); }
-//int SoftwareSerialTx::peek() { return -1; }
 int SoftwareSerialRx::peek()
 {
     if (_on_CN_pin)

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.h
@@ -146,6 +146,13 @@ class SoftwareSerialTx : virtual public SoftwareSerialBase
     explicit operator bool() { return true; }
     
     using Print::write;
+
+  private:
+    virtual int available();
+    int available(uint32_t timeout_ms);
+    virtual int peek();
+    virtual int read();
+
 };
 
 class SoftwareSerialRx : virtual public SoftwareSerialBase
@@ -232,6 +239,11 @@ class SoftwareSerialRx : virtual public SoftwareSerialBase
     explicit operator bool() { return true; }
     
     using Print::write;
+
+  private:
+    virtual size_t write(uint8_t byte);
+    virtual void flush();
+
 };
 
 class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
@@ -246,6 +258,17 @@ class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
     explicit operator bool() { return true; }
     
     using Print::write;
+
+    // From Tx
+    virtual size_t write(uint8_t byte);
+    virtual void flush();
+
+    // From Rx
+    virtual int available();
+    int available(uint32_t timeout_ms);
+    virtual int peek();
+    virtual int read();
+
 };
 
 

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.h
@@ -118,6 +118,19 @@ class SoftwareSerialBase : public Stream
   protected:
     // Record if we've set up the CN ISR (only need to do it once)
     static bool _CN_ISR_hooked;
+  private:
+    // The following private vitrual functions address the requirements for 
+    // implimenting a pure virtual funtion with non-functions. This is done 
+    // so that they don't have to be implimented in a Simplix class.
+    // Ideally the Stream class would derive from two Simplex classes but
+    // that would require upstream Arduino changes. -J. Christ 06-07Jun-2016
+    virtual size_t write(uint8_t byte) { return 0; }
+    virtual void flush() {}
+
+    virtual int available() { return 0; }
+    //int available(uint32_t timeout_ms);  // not a Stream pure vitrual function
+    virtual int peek() { return -1; }
+    virtual int read() { return 0; }
 };
 
 class SoftwareSerialTx : virtual public SoftwareSerialBase
@@ -146,13 +159,6 @@ class SoftwareSerialTx : virtual public SoftwareSerialBase
     explicit operator bool() { return true; }
     
     using Print::write;
-
-  private:
-    virtual int available();
-    int available(uint32_t timeout_ms);
-    virtual int peek();
-    virtual int read();
-
 };
 
 class SoftwareSerialRx : virtual public SoftwareSerialBase
@@ -239,11 +245,6 @@ class SoftwareSerialRx : virtual public SoftwareSerialBase
     explicit operator bool() { return true; }
     
     using Print::write;
-
-  private:
-    virtual size_t write(uint8_t byte);
-    virtual void flush();
-
 };
 
 class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
@@ -258,17 +259,6 @@ class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
     explicit operator bool() { return true; }
     
     using Print::write;
-
-    // From Tx
-    virtual size_t write(uint8_t byte);
-    virtual void flush();
-
-    // From Rx
-    virtual int available();
-    int available(uint32_t timeout_ms);
-    virtual int peek();
-    virtual int read();
-
 };
 
 

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.h
@@ -210,6 +210,8 @@ class SoftwareSerialBase : public Stream
 class SoftwareSerialTx : virtual public SoftwareSerialBase
 {
   private:
+    // per object data
+//    uint8_t     _receivePin;        // Digital pin RX is assigned to
     uint8_t     _transmitPin;       // Digital pin RX is assigned to
     long        _baudRate;
   
@@ -255,28 +257,42 @@ class SoftwareSerialTx : virtual public SoftwareSerialBase
     //void printNumber(unsigned long, uint8_t);
 
     public:
+//    // Array to hold circular RX buffer
+//    /// TODO: Can this be made private?
+//    uint8_t _rxBufferArray[TS_BUFSZ];
+//    // Circular buffer object for RX buffer management
+//    /// TODO: Can this be made private?
+//    CircularBuffer *_rxBuffer;
+//
+//    // Records the Core Timer value at the start of the start bit
+//    /// TODO: Can this be made private?
+//    uint32_t _start_bit_time;
+//
+//    // static data
+//    /// TODO: Can this be made private?
+//    static SoftwareSerialRx *active_object;
     // public methods
     SoftwareSerialTx(uint8_t transmitPin);
     ~SoftwareSerialTx();
-    //static void handleChangeNotificationISR(uint32_t start_bit_time);
+//    static void handleChangeNotificationISR(uint32_t start_bit_time);
     void begin(long speed);
     void begin(long speed, uint32_t RX_buffer_size);
-    //bool listen();
-    //int32_t readByte(void);
+//    bool listen();
+//    int32_t readByte(void);
     void end();
-    //bool isListening() { return this == active_object; }
-    //bool stopListening();
-    //bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
-
+//    bool isListening() { return this == active_object; }
+//    bool stopListening();
+//    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
+    
     // Note: has, to to be int and not int32_t for some reason
-    virtual int available();
-    int available(uint32_t timeout_ms);
+//    virtual int available();
+//    int available(uint32_t timeout_ms);
     // Note: has, to to be int and not int32_t for some reason
-    virtual int peek();
+//    virtual int peek();
     
     virtual size_t write(uint8_t byte);
     // Note: has, to to be int and not int32_t for some reason
-    virtual int read();
+//    virtual int read();
     virtual void flush();
     explicit operator bool() { return true; }
     
@@ -288,6 +304,7 @@ class SoftwareSerialRx : virtual public SoftwareSerialBase
   private:
     // per object data
     uint8_t     _receivePin;        // Digital pin RX is assigned to
+//    uint8_t     _transmitPin;       // Digital pin RX is assigned to
     long        _baudRate;
     
     // Error bit indicating that RX buffer has overflowed and some bytes have been lost
@@ -366,10 +383,10 @@ class SoftwareSerialRx : virtual public SoftwareSerialBase
     // Note: has, to to be int and not int32_t for some reason
     virtual int peek();
     
-    virtual size_t write(uint8_t byte);
+//    virtual size_t write(uint8_t byte);
     // Note: has, to to be int and not int32_t for some reason
     virtual int read();
-    virtual void flush();
+//    virtual void flush();
     explicit operator bool() { return true; }
     
     using Print::write;
@@ -422,8 +439,8 @@ class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
 //    void printNumber(unsigned long, uint8_t);
 //    
   protected:
-    // Record if we've set up the CN ISR (only need to do it once)
-    static bool _CN_ISR_hooked;
+//    // Record if we've set up the CN ISR (only need to do it once)
+//    static bool _CN_ISR_hooked;
 
   public:
 //    // Array to hold circular RX buffer
@@ -449,7 +466,7 @@ class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
     void begin(long speed, uint32_t RX_buffer_size);
 //    bool listen();
 //    int32_t readByte(void);
-//    void end();
+    void end();
 //    bool isListening() { return this == active_object; }
 //    bool stopListening();
 //    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.h
@@ -115,184 +115,33 @@ class CircularBuffer {
 
 class SoftwareSerialBase : public Stream
 {
-  private:
-//    // per object data
-//    uint8_t     _receivePin;        // Digital pin RX is assigned to
-//    uint8_t     _transmitPin;       // Digital pin RX is assigned to
-//    long        _baudRate;
-//    
-//    // Error bit indicating that RX buffer has overflowed and some bytes have been lost
-//    uint8_t _RX_buffer_overflow:1;
-//    // Error bit that indicates that a valid stop bit was not seen at some point
-//    uint8_t _invalid_stop_bit:1;
-//    // TRUE if this software serial object uses inverted logic (normally low, start bit is high, etc.)
-//    uint8_t _inverted_logic:1;
-//    // TRUE if the RX pin of this software serial object is on a Change Notice pin
-//    uint8_t _on_CN_pin:1;
-//    // TRUE when, for this RX byte, we have already captured and recorded the falling edge of the start bit
-//    uint8_t _have_start_bit_time:1;
-//    // If this RX pin is on a CN pin and this is a non-PPS CPU, then we store the bitmask of
-//    // the CN pin here (for access into CNEN register)
-//#if !defined(__PIC32_PPS__)
-//    uint32_t _CN_bitmask;
-//#endif
-//    // Records the last known state of this RX pin (when using CN)
-//    bool _last_RX_pin_state;
-//    // Port and bit mask for our RX pin
-//    p32_ioport *_rxPort;
-//    uint16_t _rxBit;
-//    // Port and bit mask for our TX pin
-//    p32_ioport *_txPort;
-//    uint16_t _txBit;
-//    // Linked list of all SoftwareSerial objects that use Change Notification pins
-//    static SoftwareSerial *CN_list_head;
-//    SoftwareSerial *next_CN;
-//    // Time, in CoreTimer ticks, of a single  bit
-//    uint32_t _OneBitTime;
-//    
-//    // private methods
-//    void IntRead(void);
-//    bool is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask);
-//    void addCN(void);
-//    void removeCN(void);
-//    static bool ReadBit(SoftwareSerial*);
-//    static bool RXBitHasChanged(SoftwareSerial*);
-//    void printNumber(unsigned long, uint8_t);
-//    
   protected:
     // Record if we've set up the CN ISR (only need to do it once)
     static bool _CN_ISR_hooked;
-
-  public:
-//    // Array to hold circular RX buffer
-//    /// TODO: Can this be made private?
-//    uint8_t _rxBufferArray[TS_BUFSZ];
-//    // Circular buffer object for RX buffer management
-//    /// TODO: Can this be made private?
-//    CircularBuffer *_rxBuffer;
-//
-//    // Records the Core Timer value at the start of the start bit
-//    /// TODO: Can this be made private?
-//    uint32_t _start_bit_time;
-//
-//    // static data
-//    /// TODO: Can this be made private?
-//    static SoftwareSerial *active_object;
-//
-//    // public methods
-//    SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic = false);
-//    ~SoftwareSerial();
-//    static void handleChangeNotificationISR(uint32_t start_bit_time);
-//    void begin(long speed);
-//    void begin(long speed, uint32_t RX_buffer_size);
-//    bool listen();
-//    int32_t readByte(void);
-//    void end();
-//    bool isListening() { return this == active_object; }
-//    bool stopListening();
-//    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
-//
-//    // Note: has, to to be int and not int32_t for some reason
-//    virtual int available();
-//    int available(uint32_t timeout_ms);
-//    // Note: has, to to be int and not int32_t for some reason
-//    virtual int peek();
-//    
-//    virtual size_t write(uint8_t byte);
-//    // Note: has, to to be int and not int32_t for some reason
-//    virtual int read();
-//    virtual void flush();
-//    explicit operator bool() { return true; }
-//    
-//    using Print::write;
 };
 
 class SoftwareSerialTx : virtual public SoftwareSerialBase
 {
   private:
     // per object data
-//    uint8_t     _receivePin;        // Digital pin RX is assigned to
     uint8_t     _transmitPin;       // Digital pin RX is assigned to
     long        _baudRate;
   
-    // Error bit indicating that RX buffer has overflowed and some bytes have been lost
-    //uint8_t _RX_buffer_overflow:1;
-    // Error bit that indicates that a valid stop bit was not seen at some point
-    //uint8_t _invalid_stop_bit:1;
-    // TRUE if this software serial object uses inverted logic (normally low, start bit is high, etc.)
-    //uint8_t _inverted_logic:1;
-    // TRUE if the RX pin of this software serial object is on a Change Notice pin
-    //uint8_t _on_CN_pin:1;
-    // TRUE when, for this RX byte, we have already captured and recorded the falling edge of the start bit
-    //uint8_t _have_start_bit_time:1;
-    // If this RX pin is on a CN pin and this is a non-PPS CPU, then we store the bitmask of
-    // the CN pin here (for access into CNEN register)
-//#if !defined(__PIC32_PPS__)
-//    uint32_t _CN_bitmask;
-//#endif
-    // Record if we've set up the CN ISR (only need to do it once)
-    //
-    //static bool _CN_ISR_hooked;
-    // Records the last known state of this RX pin (when using CN)
-    //bool _last_RX_pin_state;
-    // Port and bit mask for our RX pin
-    //p32_ioport *_rxPort;
-    //uint16_t _rxBit;
     // Port and bit mask for our TX pin
     p32_ioport *_txPort;
     uint16_t _txBit;
-    // Linked list of all SoftwareSerial objects that use Change Notification pins
-    //static SoftwareSerialTx *CN_list_head;
-    //SoftwareSerialTx *next_CN;
     // Time, in CoreTimer ticks, of a single  bit
     uint32_t _OneBitTime;
-    
-    // private methods
-    //void IntRead(void);
-    //bool is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask);
-    //void addCN(void);
-    //void removeCN(void);
-    //static bool ReadBit(SoftwareSerialRx*);
-    //static bool RXBitHasChanged(SoftwareSerialRx*);
-    //void printNumber(unsigned long, uint8_t);
 
-    public:
-//    // Array to hold circular RX buffer
-//    /// TODO: Can this be made private?
-//    uint8_t _rxBufferArray[TS_BUFSZ];
-//    // Circular buffer object for RX buffer management
-//    /// TODO: Can this be made private?
-//    CircularBuffer *_rxBuffer;
-//
-//    // Records the Core Timer value at the start of the start bit
-//    /// TODO: Can this be made private?
-//    uint32_t _start_bit_time;
-//
-//    // static data
-//    /// TODO: Can this be made private?
-//    static SoftwareSerialRx *active_object;
+  public:
     // public methods
     SoftwareSerialTx(uint8_t transmitPin);
     ~SoftwareSerialTx();
-//    static void handleChangeNotificationISR(uint32_t start_bit_time);
     void begin(long speed);
     void begin(long speed, uint32_t RX_buffer_size);
-//    bool listen();
-//    int32_t readByte(void);
     void end();
-//    bool isListening() { return this == active_object; }
-//    bool stopListening();
-//    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
-    
-    // Note: has, to to be int and not int32_t for some reason
-//    virtual int available();
-//    int available(uint32_t timeout_ms);
-    // Note: has, to to be int and not int32_t for some reason
-//    virtual int peek();
     
     virtual size_t write(uint8_t byte);
-    // Note: has, to to be int and not int32_t for some reason
-//    virtual int read();
     virtual void flush();
     explicit operator bool() { return true; }
     
@@ -304,7 +153,6 @@ class SoftwareSerialRx : virtual public SoftwareSerialBase
   private:
     // per object data
     uint8_t     _receivePin;        // Digital pin RX is assigned to
-//    uint8_t     _transmitPin;       // Digital pin RX is assigned to
     long        _baudRate;
     
     // Error bit indicating that RX buffer has overflowed and some bytes have been lost
@@ -322,9 +170,6 @@ class SoftwareSerialRx : virtual public SoftwareSerialBase
 #if !defined(__PIC32_PPS__)
     uint32_t _CN_bitmask;
 #endif
-    // Record if we've set up the CN ISR (only need to do it once)
-    //
-    //static bool _CN_ISR_hooked;
     // Records the last known state of this RX pin (when using CN)
     bool _last_RX_pin_state;
     // Port and bit mask for our RX pin
@@ -381,12 +226,9 @@ class SoftwareSerialRx : virtual public SoftwareSerialBase
     virtual int available();
     int available(uint32_t timeout_ms);
     // Note: has, to to be int and not int32_t for some reason
-    virtual int peek();
-    
-//    virtual size_t write(uint8_t byte);
+    virtual int peek();    
     // Note: has, to to be int and not int32_t for some reason
     virtual int read();
-//    virtual void flush();
     explicit operator bool() { return true; }
     
     using Print::write;
@@ -394,93 +236,13 @@ class SoftwareSerialRx : virtual public SoftwareSerialBase
 
 class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
 {
-  private:
-//    // per object data
-//    uint8_t     _receivePin;        // Digital pin RX is assigned to
-//    uint8_t     _transmitPin;       // Digital pin RX is assigned to
-//    long        _baudRate;
-//    
-//    // Error bit indicating that RX buffer has overflowed and some bytes have been lost
-//    uint8_t _RX_buffer_overflow:1;
-//    // Error bit that indicates that a valid stop bit was not seen at some point
-//    uint8_t _invalid_stop_bit:1;
-//    // TRUE if this software serial object uses inverted logic (normally low, start bit is high, etc.)
-//    uint8_t _inverted_logic:1;
-//    // TRUE if the RX pin of this software serial object is on a Change Notice pin
-//    uint8_t _on_CN_pin:1;
-//    // TRUE when, for this RX byte, we have already captured and recorded the falling edge of the start bit
-//    uint8_t _have_start_bit_time:1;
-//    // If this RX pin is on a CN pin and this is a non-PPS CPU, then we store the bitmask of
-//    // the CN pin here (for access into CNEN register)
-//#if !defined(__PIC32_PPS__)
-//    uint32_t _CN_bitmask;
-//#endif
-//    // Records the last known state of this RX pin (when using CN)
-//    bool _last_RX_pin_state;
-//    // Port and bit mask for our RX pin
-//    p32_ioport *_rxPort;
-//    uint16_t _rxBit;
-//    // Port and bit mask for our TX pin
-//    p32_ioport *_txPort;
-//    uint16_t _txBit;
-//    // Linked list of all SoftwareSerial objects that use Change Notification pins
-//    static SoftwareSerial *CN_list_head;
-//    SoftwareSerial *next_CN;
-//    // Time, in CoreTimer ticks, of a single  bit
-//    uint32_t _OneBitTime;
-//    
-//    // private methods
-//    void IntRead(void);
-//    bool is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask);
-//    void addCN(void);
-//    void removeCN(void);
-//    static bool ReadBit(SoftwareSerial*);
-//    static bool RXBitHasChanged(SoftwareSerial*);
-//    void printNumber(unsigned long, uint8_t);
-//    
-  protected:
-//    // Record if we've set up the CN ISR (only need to do it once)
-//    static bool _CN_ISR_hooked;
-
   public:
-//    // Array to hold circular RX buffer
-//    /// TODO: Can this be made private?
-//    uint8_t _rxBufferArray[TS_BUFSZ];
-//    // Circular buffer object for RX buffer management
-//    /// TODO: Can this be made private?
-//    CircularBuffer *_rxBuffer;
-//
-//    // Records the Core Timer value at the start of the start bit
-//    /// TODO: Can this be made private?
-//    uint32_t _start_bit_time;
-//
-//    // static data
-//    /// TODO: Can this be made private?
-//    static SoftwareSerial *active_object;
-//
-//    // public methods
+    // public methods
     SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic = false);
-//    ~SoftwareSerial();
-//    static void handleChangeNotificationISR(uint32_t start_bit_time);
+    // Destructor is not needed, destructors of base classes automaticly called
     void begin(long speed);
     void begin(long speed, uint32_t RX_buffer_size);
-//    bool listen();
-//    int32_t readByte(void);
     void end();
-//    bool isListening() { return this == active_object; }
-//    bool stopListening();
-//    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
-//
-//    // Note: has, to to be int and not int32_t for some reason
-//    virtual int available();
-//    int available(uint32_t timeout_ms);
-//    // Note: has, to to be int and not int32_t for some reason
-//    virtual int peek();
-//    
-//    virtual size_t write(uint8_t byte);
-//    // Note: has, to to be int and not int32_t for some reason
-//    virtual int read();
-//    virtual void flush();
     explicit operator bool() { return true; }
     
     using Print::write;

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.h
@@ -113,12 +113,181 @@ class CircularBuffer {
 };
 
 
-class SoftwareSerial : public Stream
+class SoftwareSerialBase : public Stream
+{
+  private:
+//    // per object data
+//    uint8_t     _receivePin;        // Digital pin RX is assigned to
+//    uint8_t     _transmitPin;       // Digital pin RX is assigned to
+//    long        _baudRate;
+//    
+//    // Error bit indicating that RX buffer has overflowed and some bytes have been lost
+//    uint8_t _RX_buffer_overflow:1;
+//    // Error bit that indicates that a valid stop bit was not seen at some point
+//    uint8_t _invalid_stop_bit:1;
+//    // TRUE if this software serial object uses inverted logic (normally low, start bit is high, etc.)
+//    uint8_t _inverted_logic:1;
+//    // TRUE if the RX pin of this software serial object is on a Change Notice pin
+//    uint8_t _on_CN_pin:1;
+//    // TRUE when, for this RX byte, we have already captured and recorded the falling edge of the start bit
+//    uint8_t _have_start_bit_time:1;
+//    // If this RX pin is on a CN pin and this is a non-PPS CPU, then we store the bitmask of
+//    // the CN pin here (for access into CNEN register)
+//#if !defined(__PIC32_PPS__)
+//    uint32_t _CN_bitmask;
+//#endif
+//    // Records the last known state of this RX pin (when using CN)
+//    bool _last_RX_pin_state;
+//    // Port and bit mask for our RX pin
+//    p32_ioport *_rxPort;
+//    uint16_t _rxBit;
+//    // Port and bit mask for our TX pin
+//    p32_ioport *_txPort;
+//    uint16_t _txBit;
+//    // Linked list of all SoftwareSerial objects that use Change Notification pins
+//    static SoftwareSerial *CN_list_head;
+//    SoftwareSerial *next_CN;
+//    // Time, in CoreTimer ticks, of a single  bit
+//    uint32_t _OneBitTime;
+//    
+//    // private methods
+//    void IntRead(void);
+//    bool is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask);
+//    void addCN(void);
+//    void removeCN(void);
+//    static bool ReadBit(SoftwareSerial*);
+//    static bool RXBitHasChanged(SoftwareSerial*);
+//    void printNumber(unsigned long, uint8_t);
+//    
+  protected:
+    // Record if we've set up the CN ISR (only need to do it once)
+    static bool _CN_ISR_hooked;
+
+  public:
+//    // Array to hold circular RX buffer
+//    /// TODO: Can this be made private?
+//    uint8_t _rxBufferArray[TS_BUFSZ];
+//    // Circular buffer object for RX buffer management
+//    /// TODO: Can this be made private?
+//    CircularBuffer *_rxBuffer;
+//
+//    // Records the Core Timer value at the start of the start bit
+//    /// TODO: Can this be made private?
+//    uint32_t _start_bit_time;
+//
+//    // static data
+//    /// TODO: Can this be made private?
+//    static SoftwareSerial *active_object;
+//
+//    // public methods
+//    SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic = false);
+//    ~SoftwareSerial();
+//    static void handleChangeNotificationISR(uint32_t start_bit_time);
+//    void begin(long speed);
+//    void begin(long speed, uint32_t RX_buffer_size);
+//    bool listen();
+//    int32_t readByte(void);
+//    void end();
+//    bool isListening() { return this == active_object; }
+//    bool stopListening();
+//    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
+//
+//    // Note: has, to to be int and not int32_t for some reason
+//    virtual int available();
+//    int available(uint32_t timeout_ms);
+//    // Note: has, to to be int and not int32_t for some reason
+//    virtual int peek();
+//    
+//    virtual size_t write(uint8_t byte);
+//    // Note: has, to to be int and not int32_t for some reason
+//    virtual int read();
+//    virtual void flush();
+//    explicit operator bool() { return true; }
+//    
+//    using Print::write;
+};
+
+class SoftwareSerialTx : virtual public SoftwareSerialBase
+{
+  private:
+    uint8_t     _transmitPin;       // Digital pin RX is assigned to
+    long        _baudRate;
+  
+    // Error bit indicating that RX buffer has overflowed and some bytes have been lost
+    //uint8_t _RX_buffer_overflow:1;
+    // Error bit that indicates that a valid stop bit was not seen at some point
+    //uint8_t _invalid_stop_bit:1;
+    // TRUE if this software serial object uses inverted logic (normally low, start bit is high, etc.)
+    //uint8_t _inverted_logic:1;
+    // TRUE if the RX pin of this software serial object is on a Change Notice pin
+    //uint8_t _on_CN_pin:1;
+    // TRUE when, for this RX byte, we have already captured and recorded the falling edge of the start bit
+    //uint8_t _have_start_bit_time:1;
+    // If this RX pin is on a CN pin and this is a non-PPS CPU, then we store the bitmask of
+    // the CN pin here (for access into CNEN register)
+//#if !defined(__PIC32_PPS__)
+//    uint32_t _CN_bitmask;
+//#endif
+    // Record if we've set up the CN ISR (only need to do it once)
+    //
+    //static bool _CN_ISR_hooked;
+    // Records the last known state of this RX pin (when using CN)
+    //bool _last_RX_pin_state;
+    // Port and bit mask for our RX pin
+    //p32_ioport *_rxPort;
+    //uint16_t _rxBit;
+    // Port and bit mask for our TX pin
+    p32_ioport *_txPort;
+    uint16_t _txBit;
+    // Linked list of all SoftwareSerial objects that use Change Notification pins
+    //static SoftwareSerialTx *CN_list_head;
+    //SoftwareSerialTx *next_CN;
+    // Time, in CoreTimer ticks, of a single  bit
+    uint32_t _OneBitTime;
+    
+    // private methods
+    //void IntRead(void);
+    //bool is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask);
+    //void addCN(void);
+    //void removeCN(void);
+    //static bool ReadBit(SoftwareSerialRx*);
+    //static bool RXBitHasChanged(SoftwareSerialRx*);
+    //void printNumber(unsigned long, uint8_t);
+
+    public:
+    // public methods
+    SoftwareSerialTx(uint8_t transmitPin);
+    ~SoftwareSerialTx();
+    //static void handleChangeNotificationISR(uint32_t start_bit_time);
+    void begin(long speed);
+    void begin(long speed, uint32_t RX_buffer_size);
+    //bool listen();
+    //int32_t readByte(void);
+    void end();
+    //bool isListening() { return this == active_object; }
+    //bool stopListening();
+    //bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
+
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int available();
+    int available(uint32_t timeout_ms);
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int peek();
+    
+    virtual size_t write(uint8_t byte);
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int read();
+    virtual void flush();
+    explicit operator bool() { return true; }
+    
+    using Print::write;
+};
+
+class SoftwareSerialRx : virtual public SoftwareSerialBase
 {
   private:
     // per object data
     uint8_t     _receivePin;        // Digital pin RX is assigned to
-    uint8_t     _transmitPin;       // Digital pin RX is assigned to
     long        _baudRate;
     
     // Error bit indicating that RX buffer has overflowed and some bytes have been lost
@@ -138,7 +307,7 @@ class SoftwareSerial : public Stream
 #endif
     // Record if we've set up the CN ISR (only need to do it once)
     //
-    static bool _CN_ISR_hooked;
+    //static bool _CN_ISR_hooked;
     // Records the last known state of this RX pin (when using CN)
     bool _last_RX_pin_state;
     // Port and bit mask for our RX pin
@@ -148,8 +317,8 @@ class SoftwareSerial : public Stream
     p32_ioport *_txPort;
     uint16_t _txBit;
     // Linked list of all SoftwareSerial objects that use Change Notification pins
-    static SoftwareSerial *CN_list_head;
-    SoftwareSerial *next_CN;
+    static SoftwareSerialRx *CN_list_head;
+    SoftwareSerialRx *next_CN;
     // Time, in CoreTimer ticks, of a single  bit
     uint32_t _OneBitTime;
     
@@ -158,8 +327,8 @@ class SoftwareSerial : public Stream
     bool is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask);
     void addCN(void);
     void removeCN(void);
-    static bool ReadBit(SoftwareSerial*);
-    static bool RXBitHasChanged(SoftwareSerial*);
+    static bool ReadBit(SoftwareSerialRx*);
+    static bool RXBitHasChanged(SoftwareSerialRx*);
     void printNumber(unsigned long, uint8_t);
     
   public:
@@ -176,11 +345,11 @@ class SoftwareSerial : public Stream
 
     // static data
     /// TODO: Can this be made private?
-    static SoftwareSerial *active_object;
+    static SoftwareSerialRx *active_object;
 
     // public methods
-    SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic = false);
-    ~SoftwareSerial();
+    SoftwareSerialRx(uint8_t receivePin, bool inverted_logic = false);
+    ~SoftwareSerialRx();
     static void handleChangeNotificationISR(uint32_t start_bit_time);
     void begin(long speed);
     void begin(long speed, uint32_t RX_buffer_size);
@@ -191,6 +360,100 @@ class SoftwareSerial : public Stream
     bool stopListening();
     bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
 
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int available();
+    int available(uint32_t timeout_ms);
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int peek();
+    
+    virtual size_t write(uint8_t byte);
+    // Note: has, to to be int and not int32_t for some reason
+    virtual int read();
+    virtual void flush();
+    explicit operator bool() { return true; }
+    
+    using Print::write;
+};
+
+class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
+{
+  private:
+//    // per object data
+//    uint8_t     _receivePin;        // Digital pin RX is assigned to
+//    uint8_t     _transmitPin;       // Digital pin RX is assigned to
+//    long        _baudRate;
+//    
+//    // Error bit indicating that RX buffer has overflowed and some bytes have been lost
+//    uint8_t _RX_buffer_overflow:1;
+//    // Error bit that indicates that a valid stop bit was not seen at some point
+//    uint8_t _invalid_stop_bit:1;
+//    // TRUE if this software serial object uses inverted logic (normally low, start bit is high, etc.)
+//    uint8_t _inverted_logic:1;
+//    // TRUE if the RX pin of this software serial object is on a Change Notice pin
+//    uint8_t _on_CN_pin:1;
+//    // TRUE when, for this RX byte, we have already captured and recorded the falling edge of the start bit
+//    uint8_t _have_start_bit_time:1;
+//    // If this RX pin is on a CN pin and this is a non-PPS CPU, then we store the bitmask of
+//    // the CN pin here (for access into CNEN register)
+//#if !defined(__PIC32_PPS__)
+//    uint32_t _CN_bitmask;
+//#endif
+//    // Records the last known state of this RX pin (when using CN)
+//    bool _last_RX_pin_state;
+//    // Port and bit mask for our RX pin
+//    p32_ioport *_rxPort;
+//    uint16_t _rxBit;
+//    // Port and bit mask for our TX pin
+//    p32_ioport *_txPort;
+//    uint16_t _txBit;
+//    // Linked list of all SoftwareSerial objects that use Change Notification pins
+//    static SoftwareSerial *CN_list_head;
+//    SoftwareSerial *next_CN;
+//    // Time, in CoreTimer ticks, of a single  bit
+//    uint32_t _OneBitTime;
+//    
+//    // private methods
+//    void IntRead(void);
+//    bool is_pin_a_CN(uint8_t pin, uint32_t * CN_bitmask);
+//    void addCN(void);
+//    void removeCN(void);
+//    static bool ReadBit(SoftwareSerial*);
+//    static bool RXBitHasChanged(SoftwareSerial*);
+//    void printNumber(unsigned long, uint8_t);
+//    
+  protected:
+    // Record if we've set up the CN ISR (only need to do it once)
+    static bool _CN_ISR_hooked;
+
+  public:
+//    // Array to hold circular RX buffer
+//    /// TODO: Can this be made private?
+//    uint8_t _rxBufferArray[TS_BUFSZ];
+//    // Circular buffer object for RX buffer management
+//    /// TODO: Can this be made private?
+//    CircularBuffer *_rxBuffer;
+//
+//    // Records the Core Timer value at the start of the start bit
+//    /// TODO: Can this be made private?
+//    uint32_t _start_bit_time;
+//
+//    // static data
+//    /// TODO: Can this be made private?
+//    static SoftwareSerial *active_object;
+//
+//    // public methods
+    SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverted_logic = false);
+//    ~SoftwareSerial();
+//    static void handleChangeNotificationISR(uint32_t start_bit_time);
+    void begin(long speed);
+    void begin(long speed, uint32_t RX_buffer_size);
+//    bool listen();
+//    int32_t readByte(void);
+//    void end();
+//    bool isListening() { return this == active_object; }
+//    bool stopListening();
+//    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
+//
     // Note: has, to to be int and not int32_t for some reason
     virtual int available();
     int available(uint32_t timeout_ms);

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.h
@@ -471,16 +471,16 @@ class SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx
 //    bool stopListening();
 //    bool overflow() { bool ret = _RX_buffer_overflow; if (ret) _RX_buffer_overflow = false; return ret; }
 //
-    // Note: has, to to be int and not int32_t for some reason
-    virtual int available();
-    int available(uint32_t timeout_ms);
-    // Note: has, to to be int and not int32_t for some reason
-    virtual int peek();
-    
-    virtual size_t write(uint8_t byte);
-    // Note: has, to to be int and not int32_t for some reason
-    virtual int read();
-    virtual void flush();
+//    // Note: has, to to be int and not int32_t for some reason
+//    virtual int available();
+//    int available(uint32_t timeout_ms);
+//    // Note: has, to to be int and not int32_t for some reason
+//    virtual int peek();
+//    
+//    virtual size_t write(uint8_t byte);
+//    // Note: has, to to be int and not int32_t for some reason
+//    virtual int read();
+//    virtual void flush();
     explicit operator bool() { return true; }
     
     using Print::write;

--- a/pic32/libraries/SoftwareSerial/examples/SoftwareSerialSimplex/SoftwareSerialSimplex.ino
+++ b/pic32/libraries/SoftwareSerial/examples/SoftwareSerialSimplex/SoftwareSerialSimplex.ino
@@ -1,0 +1,73 @@
+/*
+  SoftwareSerial Simplex Test Code (For chipKIT)
+
+ The purpose of this sketch is to show functional equivalence between 
+ the old full duplex SoftwareSerial class and the two new Simplex
+ SoftwareSerialRx and SoftwareSerialTx classes.
+
+ Tested with the Fubarino Mini only
+ Receives USB Serial, transmits HardwareSerial (from PC)
+ Receives SoftwareSerial, transmits SoftwareSerial (loopback)
+ Receives HardwareSerial, transmits USB Serial (back to PC)
+ 
+ Fubarino Mini
+ * Software TX (11) connect to Serial1 RX (25)
+ * Software RX (10) connect to Serial1 TX (26)
+ * 
+
+ created back in the mists of time
+ modified 25 May 2012
+ by Tom Igoe
+ based on Mikal Hart's example
+ Modified on Aug 31,2015 by Brian Schmalz for chipKIT
+ Modified on Jul 06,2016 by Jacob Christ for chipKIT (adding Simplex funtionality)
+ This example code is in the public domain.
+
+ */
+#include <SoftwareSerial.h>
+
+#define Simplex
+#ifdef Simplex
+SoftwareSerialRx mySerialRx(10); // RX
+SoftwareSerialTx mySerialTx(11); // TX
+#else
+SoftwareSerial mySerial(10, 11); // RX, TX
+#endif
+
+void setup()
+{
+  // Open serial communications and wait for port to open:
+  Serial.begin(115200);
+  while (!Serial) {
+    ;
+  }
+  
+  Serial1.begin(115200);
+
+  // set the data rate for the SoftwareSerial port
+#ifdef Simplex
+  mySerialRx.begin(115200);
+  mySerialTx.begin(115200);
+#else
+  mySerial.begin(115200);
+#endif
+}
+
+void loop() // run over and over
+{
+  // Get from USB write out to hardware
+  if (Serial.available())
+    Serial1.write(Serial.read());
+  // Get software and write out to software
+#ifdef Simplex
+  if (mySerialRx.available())
+    mySerialTx.write(mySerialRx.read());
+#else
+  if (mySerial.available())
+    mySerial.write(mySerial.read());
+#endif
+  // Get hardware and write out to USB
+  if (Serial1.available())
+    Serial.write(Serial1.read());
+}
+

--- a/pic32/libraries/SoftwareSerial/keywords.txt
+++ b/pic32/libraries/SoftwareSerial/keywords.txt
@@ -7,6 +7,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
+SoftwareSerialRx	KEYWORD1
+SoftwareSerialTx	KEYWORD1
 SoftwareSerial	KEYWORD1
 
 #######################################


### PR DESCRIPTION
This pull request splits the SoftwareSerial class into four classes to realize simplex operation:

SoftwareSeiralBase : public Stream
SoftwareSerialRx : virtual public SoftwareSerialBase
SoftwareSerialTx : virtual public SoftwareSerialBase
SoftwareSerial : public SoftwareSerialRx, public SoftwareSerialTx

It also adds an example for testing the new classes and checking that they are equivalent.
