### PR TITLE
Fix for issue 213

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 dist
 tmp
 
+*.project

--- a/pic32/cores/pic32/cpudefs.h
+++ b/pic32/cores/pic32/cpudefs.h
@@ -1138,6 +1138,11 @@
     #endif
 #endif
 
+//Fix issue 213
+#ifndef __PIC32_PPS__
+  #define OPT_BOARD_INTERNAL
+#endif
+
 //************************************************************************
 #ifndef _CPU_NAME_
     #define _CPU_NAME_    "Unknown"


### PR DESCRIPTION
This solves the problem of non-PPS PIC32s not compiling SoftwareSerial.h. To test it, the SoftwareSerial example code was used. The code was compiled all the boards available on the Platformio system and all the boards compiled except for 3 that failed for other errors.