### PR TITLE
Fix bad BRG generation in SPI transactions

### DIFF
--- a/pic32/cores/pic32/HardwareSerial_cdcacm.c
+++ b/pic32/cores/pic32/HardwareSerial_cdcacm.c
@@ -33,6 +33,7 @@
 
 #include	"HardwareSerial_cdcacm.h"
 #include	"HardwareSerial_usb.h"
+#include    "Board_Defs.h"
 
 #define PACKET_SIZE	64
 
@@ -590,7 +591,29 @@ void	cdcacm_register(cdcacm_reset_cbfn reset, cdcacm_storedata_cbfn storeData)
 	usb_configuration_descriptor(cdcacm_configuration_descriptor, sizeof(cdcacm_configuration_descriptor));
 
 	assert(check(cdcacm_string_descriptor, sizeof(cdcacm_string_descriptor)) == 3);
+#if defined(CDCACM_AUTOSERIAL)
+#define D2H(X) ((X & 0xF) < 10 ? '0' + (X & 0xF) : 'A' - 10 + (X & 0xF))
+
+    char temp[15];
+    temp[0] = 'C';
+    temp[1] = 'K';
+    temp[2] = D2H(DEVID >> 28);
+    temp[3] = D2H(DEVID >> 24);
+    temp[4] = D2H(DEVID >> 20);
+    temp[5] = D2H(DEVID >> 16);
+    temp[6] = D2H(DEVID >> 12);
+    temp[7] = D2H(DEVID >> 8);
+    temp[8] = D2H(DEVID >> 4);
+    temp[9] = D2H(DEVID);
+    temp[10] = D2H(DEVCFG3 >> 12);
+    temp[11] = D2H(DEVCFG3 >> 8);
+    temp[12] = D2H(DEVCFG3 >> 4);
+    temp[13] = D2H(DEVCFG3);
+    temp[14] = 0;
+    setStrings(CDCACM_MAN, CDCACM_PROD, temp);
+#else
     setStrings(CDCACM_MAN, CDCACM_PROD, CDCACM_SER);
+#endif
 //	usb_string_descriptor(cdcacm_string_descriptor, sizeof(cdcacm_string_descriptor));
 }
 

--- a/pic32/libraries/SPI/SPI.h
+++ b/pic32/libraries/SPI/SPI.h
@@ -137,24 +137,36 @@ private:
     uint16_t GenerateBRG(void) {
         /* Compute the baud rate divider for this frequency.
         */
-        brg = (uint16_t)((__PIC32_pbClk / (2 * DesiredSPIClockFrequency)) - 1);
+        switch (DesiredSPIClockFrequency) {
+            case SPI_CLOCK_DIV2:
+                return (__PIC32_pbClk / 16000000) * 1;
+                break;
 
-        /* Check that the baud rate value is in the correct range.
-        */
-        if (brg == 0xFFFFU) {
-            /* The user tried to set a frequency that is too high to support.
-            ** Set it to the highest supported frequency.
-            */
-            brg = 0U;
-        }
+            case SPI_CLOCK_DIV4:
+                 return(__PIC32_pbClk / 16000000) * 3;
+                break;
 
-        if (brg > 0x1FFU) {
-            /* The user tried to set a frequency that is too low to support.
-            ** Set it to the lowest supported frequency.
-            */
-            brg = 0x1FFU;
+            case SPI_CLOCK_DIV8:
+                 return(__PIC32_pbClk / 16000000) * 7;
+                break;
+
+            case SPI_CLOCK_DIV16:
+                 return(__PIC32_pbClk / 16000000) * 15;
+                break;
+
+            case SPI_CLOCK_DIV32:
+                 return(__PIC32_pbClk / 16000000) * 31;
+                break;
+
+            case SPI_CLOCK_DIV64:
+                 return(__PIC32_pbClk / 16000000) * 63;
+                break;
+
+            case SPI_CLOCK_DIV128:
+                 return(__PIC32_pbClk / 16000000) * 127;
+                break;
         }
-        return brg;
+        return (__PIC32_pbClk / 16000000) * 4;
     }
     uint32_t con;
     uint16_t brg;

--- a/pic32/libraries/SPI/SPI.h
+++ b/pic32/libraries/SPI/SPI.h
@@ -143,27 +143,27 @@ private:
                 break;
 
             case SPI_CLOCK_DIV4:
-                 return(__PIC32_pbClk / 16000000) * 3;
+                return (__PIC32_pbClk / 16000000) * 3;
                 break;
 
             case SPI_CLOCK_DIV8:
-                 return(__PIC32_pbClk / 16000000) * 7;
+                return (__PIC32_pbClk / 16000000) * 7;
                 break;
 
             case SPI_CLOCK_DIV16:
-                 return(__PIC32_pbClk / 16000000) * 15;
+                return (__PIC32_pbClk / 16000000) * 15;
                 break;
 
             case SPI_CLOCK_DIV32:
-                 return(__PIC32_pbClk / 16000000) * 31;
+                return (__PIC32_pbClk / 16000000) * 31;
                 break;
 
             case SPI_CLOCK_DIV64:
-                 return(__PIC32_pbClk / 16000000) * 63;
+                return (__PIC32_pbClk / 16000000) * 63;
                 break;
 
             case SPI_CLOCK_DIV128:
-                 return(__PIC32_pbClk / 16000000) * 127;
+                return (__PIC32_pbClk / 16000000) * 127;
                 break;
         }
         return (__PIC32_pbClk / 16000000) * 4;


### PR DESCRIPTION
SPI transactions assumed a real clock frequency instead of a clock divisor macro. This now calculates the correct frequency to use for BRG based on the difference between a 16MHz UNO and the PBClock of the PIC32.