### PR TITLE
Fixes for MZ EEPROM emulation

### DIFF
--- a/pic32/cores/pic32/System_Defs.h
+++ b/pic32/cores/pic32/System_Defs.h
@@ -49,11 +49,14 @@
 /* ------------------------------------------------------------ */
 
 #if defined(__PIC32MX1XX__) || defined(__PIC32MX2XX__)
-	#define	_EEPROM_PAGE_SIZE	256		// In 32bit words
-	#define	_EEPROM_PAGE_COUNT	4
+    #define	_EEPROM_PAGE_SIZE	256		// In 32bit words
+    #define	_EEPROM_PAGE_COUNT	4
+#elif defined(__PIC32MZ__)
+    #define _EEPROM_PAGE_SIZE   4096    // In 32bit words
+    #define _EEPROM_PAGE_COUNT  1
 #else
-	#define	_EEPROM_PAGE_SIZE	1024	// In 32bit words
-#define	_EEPROM_PAGE_COUNT	1
+    #define	_EEPROM_PAGE_SIZE	1024	// In 32bit words
+    #define	_EEPROM_PAGE_COUNT	1
 #endif
 
 /* ------------------------------------------------------------ */

--- a/pic32/cores/pic32/chipKIT-application-COMMON-MZ.ld
+++ b/pic32/cores/pic32/chipKIT-application-COMMON-MZ.ld
@@ -76,7 +76,7 @@ SECTIONS
   .eeprom_pic32 _EEPROM_ADDR (NOLOAD):
   {
     KEEP(*(.eeprom_pic32 .eeprom_pic32.*))
-  } > kseg0_eeprom_mem
+  } > kseg1_eeprom_mem
 
   .simple_tlb_refill_excpt _SIMPLE_TLB_REFILL_EXCPT_ADDR :
   {
@@ -747,8 +747,8 @@ SECTIONS
     LONG(_JUMP_ADDR)                           /* image execution address      */
     LONG(_ebase_address)                       /* image base address           */
     LONG(_IMAGE_FLASH_SIZE)                    /* size of image flash used     */
-    LONG(ORIGIN(kseg0_eeprom_mem))             /* eeprom location              */
-    LONG(LENGTH(kseg0_eeprom_mem))             /* eeprom size                  */
+    LONG(ORIGIN(kseg1_eeprom_mem))             /* eeprom location              */
+    LONG(LENGTH(kseg1_eeprom_mem))             /* eeprom size                  */
     LONG(ORIGIN(configsfrs))                   /* config bits location         */
     LONG(LENGTH(configsfrs))                   /* config bits size             */
     LONG(_ram_header_addr)                     /* ram header pointer           */

--- a/pic32/variants/Fubarino_SDZ/MZ-application-32MZ2048ECX.ld
+++ b/pic32/variants/Fubarino_SDZ/MZ-application-32MZ2048ECX.ld
@@ -74,7 +74,7 @@ MEMORY
   kseg0_vector_mem            : ORIGIN = 0x9D000000, LENGTH = 0x1000
   kseg1_vector_mem            : ORIGIN = 0xBD000000, LENGTH = 0x1000
   kseg0_program_mem    (rx)   : ORIGIN = 0x9D001000, LENGTH = 0x1FB000
-  kseg0_eeprom_mem            : ORIGIN = 0x9D1FC000, LENGTH = 0x4000
+  kseg1_eeprom_mem            : ORIGIN = 0xBD1FC000, LENGTH = 0x4000
   kseg0_boot_mem              : ORIGIN = 0x9FC004B0, LENGTH = 0x0
   kseg1_boot_mem              : ORIGIN = 0xBFC00000, LENGTH = 0x0
   kseg1_boot_mem_4B0          : ORIGIN = 0xBFC004B0, LENGTH = 0x0
@@ -241,7 +241,7 @@ _CACHE_ERR_EXCPT_ADDR           = _ebase_address + _CACHE_ERR_EXCPT_OFFSET;
 _GEN_EXCPT_ADDR                 = _ebase_address + _GEN_EXCPT_OFFSET;
 _IMAGE_PTR_TABLE                = _ebase_address + _IMAGE_PTR_TABLE_OFFSET;
 _IMAGE_HEADER_ADDR              = _ebase_address + _IMAGE_HEADER_OFFSET;
-_EEPROM_ADDR                    = ORIGIN(kseg0_eeprom_mem);
+_EEPROM_ADDR                    = ORIGIN(kseg1_eeprom_mem);
 
 /*************************************************************************
  *  Bootloader program directives.

--- a/pic32/variants/OpenScope/OpenScope.ld
+++ b/pic32/variants/OpenScope/OpenScope.ld
@@ -74,7 +74,7 @@ MEMORY
   kseg0_vector_mem            : ORIGIN = 0x9D000000, LENGTH = 0x1000
   kseg1_vector_mem            : ORIGIN = 0xBD000000, LENGTH = 0x1000
   kseg0_program_mem    (rx)   : ORIGIN = 0x9D001000, LENGTH = 0x1EF000
-  kseg0_eeprom_mem            : ORIGIN = 0x9D1F0000, LENGTH = 0x10000
+  kseg1_eeprom_mem            : ORIGIN = 0xBD1F0000, LENGTH = 0x10000
   kseg0_boot_mem              : ORIGIN = 0x9FC004B0, LENGTH = 0x0
   kseg1_boot_mem              : ORIGIN = 0xBFC00000, LENGTH = 0x0
   kseg1_boot_mem_4B0          : ORIGIN = 0xBFC004B0, LENGTH = 0x0
@@ -241,7 +241,7 @@ _CACHE_ERR_EXCPT_ADDR           = _ebase_address + _CACHE_ERR_EXCPT_OFFSET;
 _GEN_EXCPT_ADDR                 = _ebase_address + _GEN_EXCPT_OFFSET;
 _IMAGE_PTR_TABLE                = _ebase_address + _IMAGE_PTR_TABLE_OFFSET;
 _IMAGE_HEADER_ADDR              = _ebase_address + _IMAGE_HEADER_OFFSET;
-_EEPROM_ADDR                    = ORIGIN(kseg0_eeprom_mem);
+_EEPROM_ADDR                    = ORIGIN(kseg1_eeprom_mem);
 
 /*************************************************************************
  *  Bootloader program directives.

--- a/pic32/variants/WiFire/MZ-application-32MZ2048ECX.ld
+++ b/pic32/variants/WiFire/MZ-application-32MZ2048ECX.ld
@@ -74,7 +74,7 @@ MEMORY
   kseg0_vector_mem            : ORIGIN = 0x9D000000, LENGTH = 0x1000
   kseg1_vector_mem            : ORIGIN = 0xBD000000, LENGTH = 0x1000
   kseg0_program_mem    (rx)   : ORIGIN = 0x9D001000, LENGTH = 0x1FB000
-  kseg0_eeprom_mem            : ORIGIN = 0x9D1FC000, LENGTH = 0x4000
+  kseg1_eeprom_mem            : ORIGIN = 0xBD1FC000, LENGTH = 0x4000
   kseg0_boot_mem              : ORIGIN = 0x9FC004B0, LENGTH = 0x0
   kseg1_boot_mem              : ORIGIN = 0xBFC00000, LENGTH = 0x0
   kseg1_boot_mem_4B0          : ORIGIN = 0xBFC004B0, LENGTH = 0x0
@@ -241,7 +241,7 @@ _CACHE_ERR_EXCPT_ADDR           = _ebase_address + _CACHE_ERR_EXCPT_OFFSET;
 _GEN_EXCPT_ADDR                 = _ebase_address + _GEN_EXCPT_OFFSET - 0x30;
 _IMAGE_PTR_TABLE                = _ebase_address + _IMAGE_PTR_TABLE_OFFSET;
 _IMAGE_HEADER_ADDR              = _ebase_address + _IMAGE_HEADER_OFFSET;
-_EEPROM_ADDR                    = ORIGIN(kseg0_eeprom_mem);
+_EEPROM_ADDR                    = ORIGIN(kseg1_eeprom_mem);
 
 /*************************************************************************
  *  Bootloader program directives.


### PR DESCRIPTION
Add MZ page size definition and move EEPROM memory from kseg0 to kseg1 to remove caching.