### PR TITLE
Reimplemented the Arduino __FlashStringHelper class 

### DIFF
--- a/pic32/cores/pic32/Print.cpp
+++ b/pic32/cores/pic32/Print.cpp
@@ -44,6 +44,10 @@ size_t Print::print(const String &s)
   return write(s.c_str(), s.length());
 }
 
+size_t Print::print(const __FlashStringHelper *s) {
+    print((const char *)s);
+}
+
 size_t Print::print(const char str[])
 {
   return write(str);
@@ -113,6 +117,10 @@ size_t Print::println(const String &s)
   size_t n = print(s);
   n += println();
   return n;
+}
+
+size_t Print::println(const __FlashStringHelper *s) {
+    println((const char *)s);
 }
 
 size_t Print::println(const char c[])

--- a/pic32/cores/pic32/Print.h
+++ b/pic32/cores/pic32/Print.h
@@ -56,6 +56,7 @@ class Print
       return write((const uint8_t *)buffer, size);
     }
     
+    size_t print(const __FlashStringHelper *);
     size_t print(const String &);
     size_t print(const char[]);
     size_t print(char);
@@ -67,6 +68,7 @@ class Print
     size_t print(double, int = 2);
     size_t print(const Printable&);
 
+    size_t println(const __FlashStringHelper *);
     size_t println(const String &s);
     size_t println(const char[]);
     size_t println(char);

--- a/pic32/cores/pic32/WProgram.h
+++ b/pic32/cores/pic32/WProgram.h
@@ -20,14 +20,6 @@
 	#include "HardwareSerial.h"
 #endif
 
-//Compatability changes
-#if defined(__PIC32MX__)
-  #if defined F
-    #undef F
-  #endif
-  #define F(X) (X)
-#endif
-
 uint16_t makeWord(uint16_t w);
 uint16_t makeWord(byte h, byte l);
 

--- a/pic32/cores/pic32/WString.cpp
+++ b/pic32/cores/pic32/WString.cpp
@@ -57,6 +57,12 @@ String::String(const String &value)
 	*this = value;
 }
 
+String::String(const __FlashStringHelper *pstr)
+{
+    init();
+    *this = pstr;
+}
+
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
 String::String(String &&rval)
 {
@@ -192,6 +198,19 @@ String & String::copy(const char *cstr, unsigned int length)
 	return *this;
 }
 
+String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
+{
+    if (!reserve(length)) {
+        invalidate();
+        return *this;
+    }
+    len = length;
+    strcpy(buffer, (const char *)pstr);
+    return *this;
+}
+
+    
+
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
 void String::move(String &rhs)
 {
@@ -245,6 +264,15 @@ String & String::operator = (const char *cstr)
 	
 	return *this;
 }
+
+String & String::operator = (const __FlashStringHelper *pstr)
+{
+    if (pstr) copy(pstr, strlen((const char *)pstr));
+    else invalidate();
+
+    return *this;
+}
+
 
 /*********************************************/
 /*  concat                                   */
@@ -329,6 +357,19 @@ unsigned char String::concat(double num)
 	return concat(string, strlen(string));
 }
 
+unsigned char String::concat(const __FlashStringHelper * str)
+{
+    if (!str) return 0;
+    int length = strlen((const char *) str);
+    if (length == 0) return 1;
+    unsigned int newlen = len + length;
+    if (!reserve(newlen)) return 0;
+    strcpy(buffer + len, (const char *) str);
+    len = newlen;
+    return 1;
+}
+
+
 /*********************************************/
 /*  Concatenate                              */
 /*********************************************/
@@ -402,6 +443,14 @@ StringSumHelper & operator + (const StringSumHelper &lhs, double num)
 	if (!a.concat(num)) a.invalidate();
 	return a;
 }
+
+StringSumHelper & operator + (const StringSumHelper &lhs, const __FlashStringHelper *rhs)
+{
+    StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+    if (!a.concat(rhs)) a.invalidate();
+    return a;
+}
+
 /*********************************************/
 /*  Comparison                               */
 /*********************************************/

--- a/pic32/cores/pic32/WString.h
+++ b/pic32/cores/pic32/WString.h
@@ -33,8 +33,12 @@
 //     -felide-constructors
 //     -std=c++0x
 
-typedef const char * __FlashStringHelper;
-#define F(string_literal) (string_literal)
+//typedef  char __FlashStringHelper;
+//#define F(string_literal) (string_literal)
+
+class __FlashStringHelper;
+#define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(string_literal))
+
 
 extern char *dtostrf(double __val, signed char __width, unsigned char __prec, char *__s);
 
@@ -60,6 +64,7 @@ public:
 	// be false).
 	String(const char *cstr = "");
 	String(const String &str);
+    String(const __FlashStringHelper *str);
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	String(String &&rval);
 	String(StringSumHelper &&rval);
@@ -86,6 +91,7 @@ public:
 	// marked as invalid ("if (s)" will be false).
 	String & operator = (const String &rhs);
 	String & operator = (const char *cstr);
+    String & operator = (const __FlashStringHelper *str);
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	String & operator = (String &&rval);
 	String & operator = (StringSumHelper &&rval);
@@ -106,6 +112,7 @@ public:
 	unsigned char concat(unsigned long num);
 	unsigned char concat(float num);
 	unsigned char concat(double num);
+    unsigned char concat(const __FlashStringHelper * str);
 	
 	// if there's not enough memory for the concatenated value, the string
 	// will be left unchanged (but this isn't signalled in any way)
@@ -117,6 +124,8 @@ public:
 	String & operator += (unsigned int num)		{concat(num); return (*this);}
 	String & operator += (long num)			{concat(num); return (*this);}
 	String & operator += (unsigned long num)	{concat(num); return (*this);}
+    String & operator += (const __FlashStringHelper *str){concat(str); return (*this);}
+
 
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs);
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr);
@@ -128,6 +137,7 @@ public:
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num);
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, float num);
 	friend StringSumHelper & operator + (const StringSumHelper &lhs, double num);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, const __FlashStringHelper *rhs);
 
 	// comparison (only works w/ Strings and "strings")
 	operator StringIfHelperType() const { return buffer ? &String::StringIfHelper : 0; }
@@ -195,6 +205,7 @@ protected:
 
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);
+    String & copy(const __FlashStringHelper *pstr, unsigned int length);
 	#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	void move(String &rhs);
 	#endif


### PR DESCRIPTION
...and associated helper functions.

This puts in the standard __FlashStringHelper class and associated member functions for handling it. All it does within those helpers is cast the incoming pointer to a "const char *" and work normally. 