### PR TITLE
Added LED_BUILTIN to Board_Defs.h

### DIFF
--- a/pic32/variants/CUI32stem/Board_Defs.h
+++ b/pic32/variants/CUI32stem/Board_Defs.h
@@ -84,6 +84,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 64
 #define	PIN_LED1	64
 
 /* ------------------------------------------------------------ */

--- a/pic32/variants/Cerebot_32MX4/Board_Defs.h
+++ b/pic32/variants/Cerebot_32MX4/Board_Defs.h
@@ -91,6 +91,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 60
 #define	PIN_LED1	60
 #define	PIN_LED2	61
 #define	PIN_LED3	62

--- a/pic32/variants/Cerebot_32MX7/Board_Defs.h
+++ b/pic32/variants/Cerebot_32MX7/Board_Defs.h
@@ -91,6 +91,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 51
 #define	PIN_LED1	51
 #define	PIN_LED2	52
 #define	PIN_LED3	53

--- a/pic32/variants/Cerebot_MX3cK/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX3cK/Board_Defs.h
@@ -92,6 +92,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 42
 #define	PIN_LED1	42
 #define	PIN_LED2	43
 

--- a/pic32/variants/Cerebot_MX3cK_512/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX3cK_512/Board_Defs.h
@@ -84,6 +84,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 42
 #define	PIN_LED1	42
 #define	PIN_LED2	43
 

--- a/pic32/variants/Cerebot_MX4cK/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX4cK/Board_Defs.h
@@ -92,6 +92,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 64
 #define	PIN_LED1	64
 #define	PIN_LED2	65
 #define	PIN_LED3	66

--- a/pic32/variants/Cerebot_MX7cK/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX7cK/Board_Defs.h
@@ -92,6 +92,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 51
 #define	PIN_LED1	51
 #define	PIN_LED2	52
 #define	PIN_LED3	53

--- a/pic32/variants/ChipKIT_Pi/Board_Defs.h
+++ b/pic32/variants/ChipKIT_Pi/Board_Defs.h
@@ -88,6 +88,7 @@
 /* Define the pin numbers for the LEDs
 NOTE: The ChipKIT Pi has two user LEDs
 */
+#define LED_BUILTIN 14
 #define	PIN_LED1	14      // 11  RA0
 #define	PIN_LED2	15      // 14  RB15
 
@@ -280,7 +281,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					Serial Port Declarations					*/
 /* ------------------------------------------------------------ */
 
-/* Serial port 0 uses UART1 – for the serial monitor
+/* Serial port 0 uses UART1 Â– for the serial monitor
 */
 #define       _SER0_BASE           _UART1_BASE_ADDRESS
 #define       _SER0_IRQ            _UART1_ERR_IRQ

--- a/pic32/variants/Cmod/Board_Defs.h
+++ b/pic32/variants/Cmod/Board_Defs.h
@@ -85,6 +85,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 14
 #define	PIN_LED1	14      // 14  RA10 PGED(4)/TMS/PMA10/RA10
 #define	PIN_LED2	12      // 12  RB12 AN12/PMD0/RB12
 
@@ -305,7 +306,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					Serial Port Declarations					*/
 /* ------------------------------------------------------------ */
 
-/* Serial port 0 uses UART1 – for the serial monitor
+/* Serial port 0 uses UART1 Â– for the serial monitor
 */
 #define       _SER0_BASE           _UART1_BASE_ADDRESS
 #define       _SER0_IRQ            _UART1_ERR_IRQ

--- a/pic32/variants/DP32/Board_Defs.h
+++ b/pic32/variants/DP32/Board_Defs.h
@@ -88,6 +88,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	14      // 14  AN5/C1INA/C2INC/RTCC/RPB3/SCL2/PMWR/RB3
 #define	PIN_LED2	13      // 13  AN4/C1INB/C2IND/RPB2/SDA2/CTED13/PMD2/RB2
 #define	PIN_LED3	12      // 12  PGEC1/AN3/C1INC/C2INA/RPB1/CTED12/PMD1/RB1 
@@ -286,7 +287,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					Serial Port Declarations					*/
 /* ------------------------------------------------------------ */
 
-/* Serial port 0 uses UART1 – for the serial monitor
+/* Serial port 0 uses UART1 Â– for the serial monitor
 */
 #define       _SER0_BASE           _UART1_BASE_ADDRESS
 #define       _SER0_IRQ            _UART1_ERR_IRQ

--- a/pic32/variants/Default_100/Board_Defs.h
+++ b/pic32/variants/Default_100/Board_Defs.h
@@ -84,6 +84,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	13
 
 /* ------------------------------------------------------------ */

--- a/pic32/variants/Default_64/Board_Defs.h
+++ b/pic32/variants/Default_64/Board_Defs.h
@@ -84,6 +84,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	13
 
 /* ------------------------------------------------------------ */

--- a/pic32/variants/Fubarino_Mini/Board_Defs.h
+++ b/pic32/variants/Fubarino_Mini/Board_Defs.h
@@ -85,6 +85,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 1
 #define	PIN_LED1	1
 
 /* ------------------------------------------------------------ */

--- a/pic32/variants/Fubarino_SD/Board_Defs.h
+++ b/pic32/variants/Fubarino_SD/Board_Defs.h
@@ -85,6 +85,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 21
 #define	PIN_LED1	21
 
 /* ------------------------------------------------------------ */

--- a/pic32/variants/Fubarino_SDZ/Board_Defs.h
+++ b/pic32/variants/Fubarino_SDZ/Board_Defs.h
@@ -100,6 +100,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	13
 #define	PIN_LED2	43
 #define	PIN_LED3	44

--- a/pic32/variants/Lenny/Board_Defs.h
+++ b/pic32/variants/Lenny/Board_Defs.h
@@ -96,6 +96,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 22
 #define	PIN_LED1	22
 #define	PIN_LED2	23
 #define	PIN_LED3	24
@@ -290,7 +291,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					Serial Port Declarations					*/
 /* ------------------------------------------------------------ */
 
-/* Serial port 0 uses UART1 – for the serial monitor
+/* Serial port 0 uses UART1 Â– for the serial monitor
 */
 #define       _SER0_BASE           _UART2_BASE_ADDRESS
 #define       _SER0_IRQ            _UART2_ERR_IRQ

--- a/pic32/variants/Max32/Board_Defs.h
+++ b/pic32/variants/Max32/Board_Defs.h
@@ -92,6 +92,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN	13
 #define	PIN_LED1	13
 #define	PIN_LED2	86
 

--- a/pic32/variants/Olimex_PIC32_Pinguino/Board_Defs.h
+++ b/pic32/variants/Olimex_PIC32_Pinguino/Board_Defs.h
@@ -86,6 +86,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	13
 #define	PIN_LED2	14
 

--- a/pic32/variants/OpenScope/Board_Defs.h
+++ b/pic32/variants/OpenScope/Board_Defs.h
@@ -103,6 +103,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	13
 #define	PIN_LED2	48
 #define	PIN_LED3	49

--- a/pic32/variants/PONTECH_UAV100/Board_Defs.h
+++ b/pic32/variants/PONTECH_UAV100/Board_Defs.h
@@ -88,6 +88,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 80
 #define	PIN_LED1	80
 
 /* ------------------------------------------------------------ */

--- a/pic32/variants/Uno32/Board_Defs.h
+++ b/pic32/variants/Uno32/Board_Defs.h
@@ -99,6 +99,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
+#define LED_BUILTIN	13
 #define	PIN_LED1	13
 #define	PIN_LED2	43
 

--- a/pic32/variants/Uno32_Pmod_Shield/Board_Defs.h
+++ b/pic32/variants/Uno32_Pmod_Shield/Board_Defs.h
@@ -99,6 +99,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
+#define LED_BUILTIN	13
 #define	PIN_LED1	13
 #define	PIN_LED2	43
 #define	PIN_LED3	3

--- a/pic32/variants/WF32/Board_Defs.h
+++ b/pic32/variants/WF32/Board_Defs.h
@@ -99,6 +99,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	13
 #define	PIN_LED2	43
 #define	PIN_LED3	48

--- a/pic32/variants/WiFire/Board_Defs.h
+++ b/pic32/variants/WiFire/Board_Defs.h
@@ -103,6 +103,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	13
 #define	PIN_LED2	43
 #define	PIN_LED3	44

--- a/pic32/variants/openbci/Board_Defs.h
+++ b/pic32/variants/openbci/Board_Defs.h
@@ -89,6 +89,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN 13
 #define	PIN_LED1	14      // 14  AN5/C1INA/C2INC/RTCC/RPB3/SCL2/PMWR/RB3
 #define	PIN_LED2	13      // 13  AN4/C1INB/C2IND/RPB2/SDA2/CTED13/PMD2/RB2
 #define	PIN_LED3	12      // 12  PGEC1/AN3/C1INC/C2INA/RPB1/CTED12/PMD1/RB1 
@@ -287,7 +288,7 @@ extern const uint8_t	external_int_to_digital_pin_PGM[];
 /*					Serial Port Declarations					*/
 /* ------------------------------------------------------------ */
 
-/* Serial port 0 uses UART1 – for the serial monitor
+/* Serial port 0 uses UART1 Â– for the serial monitor
 */
 #define       _SER0_BASE           _UART1_BASE_ADDRESS
 #define       _SER0_IRQ            _UART1_ERR_IRQ

--- a/pic32/variants/picadillo_35t/Board_Defs.h
+++ b/pic32/variants/picadillo_35t/Board_Defs.h
@@ -31,6 +31,7 @@
 #define	NUM_ANALOG_PINS_EXTENDED	NUM_ANALOG_PINS
 
 // LED is the LCD backlight RD2, "pin" 32.
+#define LED_BUILTIN 32
 #define PIN_LED1    32
 #define PIN_BACKLIGHT   32
 

--- a/pic32/variants/quicK240/Board_Defs.h
+++ b/pic32/variants/quicK240/Board_Defs.h
@@ -139,6 +139,7 @@
 
 /* Define the pin numbers for the LEDs
 */
+#define LED_BUILTIN	37
 #define	PIN_LED1	37
 #define	PIN_LED2	81
 

--- a/pic32/variants/uC32/Board_Defs.h
+++ b/pic32/variants/uC32/Board_Defs.h
@@ -88,7 +88,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
-#define LED_BUILTIN 	13
+#define	LED_BUILTIN	13
 #define	PIN_LED1	13
 #define	PIN_LED2	43
 

--- a/pic32/variants/uC32/Board_Defs.h
+++ b/pic32/variants/uC32/Board_Defs.h
@@ -88,6 +88,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
+#define LED_BUILTIN 	13
 #define	PIN_LED1	13
 #define	PIN_LED2	43
 

--- a/pic32/variants/uC32_Pmod_Shield/Board_Defs.h
+++ b/pic32/variants/uC32_Pmod_Shield/Board_Defs.h
@@ -88,6 +88,7 @@
 
 /* Define the pin numbers for the LEDs.
 */
+#define LED_BUILTIN	13
 #define	PIN_LED1	13
 #define	PIN_LED2	43
 #define	PIN_LED3	3


### PR DESCRIPTION
The Arduino project has added LED_BUILTIN to their official list of Constants. See https://www.arduino.cc/en/Reference/Constants

They have also updated their examples to use LED_BUILTIN which means it must be defined in variants of Board_Defs.h in order to compile some of their examples. This will likely be an issue in most chipKIT variants.