### PR TITLE
Added LED_BUILTIN to pins_arduino.h

### DIFF
--- a/pic32/cores/pic32/pins_arduino.h
+++ b/pic32/cores/pic32/pins_arduino.h
@@ -295,6 +295,10 @@ extern const uint8_t ext_int_to_pps_sel_PGM[];
 #define	NUM_ANALOG_PINS_EXTENDED	NUM_ANALOG_PINS
 #endif
 
+#if !defined(LED_BUILTIN)
+#define LED_BUILTIN PIN_LED1
+#endif
+
 /* ------------------------------------------------------------ */
 
 #endif		// PINS_ARDUINO_H


### PR DESCRIPTION
LED_BUILTIN is missing from all chipKIT board variants. This change adds it to pins_arduino.h which should map the PIN_LED1 from each board variants Board_Defs.h file to LED_BUILTIN while still allowing it to be specifically defined in Board_Defs.h should someone decide that PIN_LED1 doesn't make sense for their particular board.