### PR TITLE
Non-blocking analogRead() functions added.

### DIFF
--- a/pic32/cores/pic32/wiring.h
+++ b/pic32/cores/pic32/wiring.h
@@ -144,6 +144,12 @@ void	pinMode(uint8_t pin, uint8_t mode);
 uint8_t	getPinMode(uint8_t pin);
 void	digitalWrite(uint8_t pin, uint8_t val);
 int		digitalRead(uint8_t pin);
+
+// These analogRead funcitons allow for non-blocking use of ADC
+uint8_t analogReadConversionStart(uint8_t pin);
+inline uint32_t analogReadConversionComplete();
+uint32_t analogReadConversion();
+
 int		analogRead(uint8_t);
 void	analogReference(uint8_t mode);
 void	analogWrite(uint8_t, int);

--- a/pic32/cores/pic32/wiring_analog.c
+++ b/pic32/cores/pic32/wiring_analog.c
@@ -111,11 +111,16 @@ int _board_analogReference(uint8_t mode);
 //*	I commented out the code using the Microchip PIC32 Peripheral Libraries and substituted 
 //*	direct writes to the registers as shown below. This fixed all problems and works great:
 //*********************************************************************
-int analogRead(uint8_t pin)
-{
-	int analogValue = 0;
-	uint8_t	channelNumber;
-	uint8_t ain;
+//* These analogRead functions are to speed up the analogRead functions
+//* of the chipKIT-core by allowing for non-blocking calls to 
+//* analogReadConversionComplete() from our loop() while at the same
+//* time not breaking existing analogRead functionality.
+//* -J. Christ Nov 2016
+//*********************************************************************
+uint8_t	_analogRead_channelNumber; // breaking up analogRead required making a shared global 
+
+uint8_t analogReadConversionStart(uint8_t pin){
+  uint8_t ain;
 
 	/* Check if pin number is in valid range.
 	*/
@@ -149,7 +154,7 @@ int	tmp;
 	** A/D converter. In some cases this is a direct mapping. In that case,
 	** the conversion macro just returns it parameter.
 	*/
-	channelNumber = analogInPinToChannel(ain);
+	_analogRead_channelNumber = analogInPinToChannel(ain);
 
 	/* Ensure that the pin associated with the analog channel is in analog
 	** input mode, and select the channel in the input mux.
@@ -209,32 +214,115 @@ int	tmp;
 	**  with PORTB to analog input or digital input mode. Clear the appropriate
 	**  bit in AD1PCFG.
 	*/
-	AD1PCFGCLR = (1 << channelNumber);
+	AD1PCFGCLR = (1 << _analogRead_channelNumber);
 #endif		// defined(__PIC32_PPS__)
 
 #if defined(__PIC32MZXX__)
 
 // If alternate ADC implementation
 #if defined(__ALT_ADC_IMPL__)
-    analogValue = convertADC(channelNumber);
+    // As of this writing only WiFire and OpenScope use this feature.
+    // for now, return true and let _analogReadConversion be blocking for these boards
+    return true;
+
+// EC MZ ADC code
+#elif defined(__PIC32MZECADC__)
+    #warning return true and let _analogReadConversion be blocking for these chips
+    return true;
+
+#elif defined(__PIC32MZEFADC__)
+    #error EF ADC code not implemented yet
+
+#else
+    #error ADC code for this MZ must be added in WSystems.c and wiring_analog.c
+#endif
+
+#else
+	AD1CHS = (_analogRead_channelNumber & 0xFFFF) << 16;
+	AD1CON1	=	0; //Ends sampling, and starts converting
+
+	/* Set up for manual sampling
+	*/
+	AD1CSSL	=	0;
+	AD1CON3	=	0x000B;	//Tad = internal 22 Tpb
+	AD1CON2	=	analog_reference;
+
+	/* Turn on ADC
+	*/
+	AD1CON1SET	=	0x8000;
+	
+	/* Start sampling
+	*/
+	AD1CON1SET	=	0x0002;
+	
+	/* Delay for a bit
+	*/
+	delayMicroseconds(2);
+
+	/* Start conversion
+	*/
+	AD1CON1CLR	=	0x0002;
+	
+#endif
+
+  return true; // assume everthing worked until we have time to write better code.
+}
+
+inline uint32_t analogReadConversionComplete(){
+
+#if defined(__PIC32MZXX__)
+
+// If alternate ADC implementation
+#if defined(__ALT_ADC_IMPL__)
+    // As of this writing only WiFire and OpenScope use this feature.
+    // for now, return true and let _analogReadConversion be blocking for these chips
+    return true;
+
+// EC MZ ADC code
+#elif defined(__PIC32MZECADC__)
+    #warning return true and let _analogReadConversion be blocking for these chips
+    return true;
+#elif defined(__PIC32MZEFADC__)
+    #error EF ADC code not implemented yet
+
+#else
+    #error ADC code for this MZ must be added in WSystems.c and wiring_analog.c
+#endif
+
+#else
+	// Wait for conversion to finish
+	return (AD1CON1 & 0x0001);
+#endif
+  
+}
+
+uint32_t analogReadConversion(){
+
+	int analogValue = 0;
+
+#if defined(__PIC32MZXX__)
+
+// If alternate ADC implementation
+#if defined(__ALT_ADC_IMPL__)
+    analogValue = convertADC(_analogRead_channelNumber);
 
 // EC MZ ADC code
 #elif defined(__PIC32MZECADC__)
 { 
     int i,k         = 0;
-    uint8_t vcn     = channelNumber;
+    uint8_t vcn     = _analogRead_channelNumber;
 
     #define KVA_2_PA(v)             (((uint32_t) (v)) & 0x1fffffff)
     static uint16_t __attribute__((coherent)) ovsampValue;
 
     // set the channel trigger for GSWTRG source triggering
-    if(channelNumber == 43 || channelNumber == 44 || channelNumber >= 50)
+    if(_analogRead_channelNumber == 43 || _analogRead_channelNumber == 44 || _analogRead_channelNumber >= 50)
     {
         return(0);
     }
-    else if(channelNumber >= 45 )
+    else if(_analogRead_channelNumber >= 45 )
     {
-        vcn = channelNumber - 45;
+        vcn = _analogRead_channelNumber - 45;
         AD1IMOD |= 1 << ((vcn * 2) + 16);               // say use the alt; set SHxALT
     }
 
@@ -310,7 +398,7 @@ int	tmp;
     AD1CON3bits.ADINSEL = 0;
     AD1FLTR6            = 0;
 
-    if(channelNumber >= 45 )
+    if(_analogRead_channelNumber >= 45 )
     {
         AD1IMOD &= ~(0b11 << ((vcn * 2) + 16));               // don't use alt
     }
@@ -324,42 +412,18 @@ int	tmp;
 #endif
 
 #else
-	AD1CHS = (channelNumber & 0xFFFF) << 16;
-	AD1CON1	=	0; //Ends sampling, and starts converting
-
-	/* Set up for manual sampling
-	*/
-	AD1CSSL	=	0;
-	AD1CON3	=	0x000B;	//Tad = internal 22 Tpb
-	AD1CON2	=	analog_reference;
-
-	/* Turn on ADC
-	*/
-	AD1CON1SET	=	0x8000;
-	
-	/* Start sampling
-	*/
-	AD1CON1SET	=	0x0002;
-	
-	/* Delay for a bit
-	*/
-	delayMicroseconds(2);
-
-	/* Start conversion
-	*/
-	AD1CON1CLR	=	0x0002;
-	
-	/* Wait for conversion to finish
-	*/
-	while (!(AD1CON1 & 0x0001));
-	
-
-	/* Read the ADC Value
-	*/
+	// Read the ADC Value
 	analogValue	=	ADC1BUF0;
 #endif
-	
+
 	return (analogValue);
+}
+
+int analogRead(uint8_t pin)
+{
+  analogReadConversionStart(pin);
+  while( ! analogReadConversionComplete() );
+  return analogReadConversion();
 }
 
 //*********************************************************************


### PR DESCRIPTION
This addresses issue #289: Split up analogRead() so that it can be used both as blocking and non-blocking.

This commit does this for MX and MZ ECG parts.  The following are not implemented yet: MZ EFG, WiFire and OpenScope.