### PR TITLE
Replaced interrupt attributes with __USER_ISR

### DIFF
--- a/pic32/cores/pic32/HardwareSerial.cpp
+++ b/pic32/cores/pic32/HardwareSerial.cpp
@@ -132,14 +132,14 @@ static void RXLedSwitchOff(int id, void *tptr) {
 
 extern "C"
 {
-void __attribute__((interrupt(),nomips16)) IntSer0Handler(void);
-void __attribute__((interrupt(),nomips16)) IntSer1Handler(void);
-void __attribute__((interrupt(),nomips16)) IntSer2Handler(void);
-void __attribute__((interrupt(),nomips16)) IntSer3Handler(void);
-void __attribute__((interrupt(),nomips16)) IntSer4Handler(void);
-void __attribute__((interrupt(),nomips16)) IntSer5Handler(void);
-void __attribute__((interrupt(),nomips16)) IntSer6Handler(void);
-void __attribute__((interrupt(),nomips16)) IntSer7Handler(void);
+void __USER_ISR IntSer0Handler(void);
+void __USER_ISR IntSer1Handler(void);
+void __USER_ISR IntSer2Handler(void);
+void __USER_ISR IntSer3Handler(void);
+void __USER_ISR IntSer4Handler(void);
+void __USER_ISR IntSer5Handler(void);
+void __USER_ISR IntSer6Handler(void);
+void __USER_ISR IntSer7Handler(void);
 }
 
 /* ------------------------------------------------------------ */
@@ -1026,11 +1026,7 @@ extern "C" {
 */
 #if defined(_SER0_VECTOR)
 
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_SER0_VECTOR),interrupt(_SER0_IPL_ISR))) IntSer0Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntSer0Handler(void)
-#endif
+void __USER_ISR IntSer0Handler(void)
 {
 #if defined(_USB) && defined(_USE_USB_FOR_SERIAL_)
 	Serial0.doSerialInt();
@@ -1057,12 +1053,7 @@ void __attribute__((interrupt(), nomips16)) IntSer0Handler(void)
 **		serial port 1.
 */
 #if defined(_SER1_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_SER1_VECTOR),interrupt(_SER1_IPL_ISR))) IntSer1Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntSer1Handler(void)
-#endif
+void __USER_ISR IntSer1Handler(void)
 {
 	Serial1.doSerialInt();
 }
@@ -1085,12 +1076,7 @@ void __attribute__((interrupt(), nomips16)) IntSer1Handler(void)
 **		serial port 2.
 */
 #if defined(_SER2_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_SER2_VECTOR),interrupt(_SER2_IPL_ISR))) IntSer2Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntSer2Handler(void)
-#endif
+void __USER_ISR IntSer2Handler(void)
 {
 	Serial2.doSerialInt();
 }
@@ -1113,12 +1099,7 @@ void __attribute__((interrupt(), nomips16)) IntSer2Handler(void)
 **		serial port 3.
 */
 #if defined(_SER3_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_SER3_VECTOR),interrupt(_SER3_IPL_ISR))) IntSer3Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntSer3Handler(void)
-#endif
+void __USER_ISR IntSer3Handler(void)
 {
 	Serial3.doSerialInt();
 }
@@ -1141,12 +1122,7 @@ void __attribute__((interrupt(), nomips16)) IntSer3Handler(void)
 **		serial port 4.
 */
 #if defined(_SER4_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_SER4_VECTOR),interrupt(_SER4_IPL_ISR))) IntSer4Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntSer4Handler(void)
-#endif
+void __USER_ISR IntSer4Handler(void)
 {
 	Serial4.doSerialInt();
 }
@@ -1169,12 +1145,7 @@ void __attribute__((interrupt(), nomips16)) IntSer4Handler(void)
 **		serial port 5.
 */
 #if defined(_SER5_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_SER5_VECTOR),interrupt(_SER5_IPL_ISR))) IntSer5Handler(void)
-#else
- void __attribute__((interrupt(), nomips16)) IntSer5Handler(void)
-#endif
+void __USER_ISR IntSer5Handler(void)
 {
 	Serial5.doSerialInt();
 }
@@ -1197,12 +1168,7 @@ void __attribute__((nomips16,at_vector(_SER5_VECTOR),interrupt(_SER5_IPL_ISR))) 
 **		serial port 6.
 */
 #if defined(_SER6_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_SER6_VECTOR),interrupt(_SER6_IPL_ISR))) IntSer6Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntSer6Handler(void)
-#endif
+void __USER_ISR IntSer6Handler(void)
 {
 	Serial6.doSerialInt();
 }
@@ -1225,12 +1191,7 @@ void __attribute__((interrupt(), nomips16)) IntSer6Handler(void)
 **		serial port 7.
 */
 #if defined(_SER7_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_SER7_VECTOR),interrupt(_SER7_IPL_ISR))) IntSer7Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntSer7Handler(void)
-#endif
+void __USER_ISR IntSer7Handler(void)
 {
 	Serial7.doSerialInt();
 }

--- a/pic32/cores/pic32/HardwareSerial_usb.c
+++ b/pic32/cores/pic32/HardwareSerial_usb.c
@@ -35,7 +35,11 @@
 #include "HardwareSerial_cdcacm.h"
 #include "System_Defs.h"
 
-void __attribute__((vector(_USB_1_VECTOR), interrupt(_USB_IPL_ISR), nomips16)) IntUSB1Handler(void);
+#ifdef _USE_USB_IRQ_
+void __USER_ISR IntUSB1Handler(void);
+#else
+void IntUSB1Handler(void);
+#endif
 
 // XXX -- move to relocated compat.h
 #define MCF_USB_OTG_CTL  U1CON
@@ -328,7 +332,7 @@ static byte next_address;	// set after successful status
 // called by usb on device attach
 //************************************************************************
 #ifdef _USE_USB_IRQ_
-	void __attribute__((vector(_USB_1_VECTOR), interrupt(_USB_IPL_ISR),nomips16)) IntUSB1Handler(void)
+	void __USER_ISR IntUSB1Handler(void)
 #else
 	void	usb_isr(void)
 #endif

--- a/pic32/cores/pic32/Tone.cpp
+++ b/pic32/cores/pic32/Tone.cpp
@@ -65,7 +65,7 @@
 #include "p32_defs.h"
 #include "pins_arduino.h"
 
-extern "C" void __attribute__((interrupt(),nomips16)) Timer1Handler(void);
+extern "C" void __USER_ISR Timer1Handler(void);
 
 //	timerx_toggle_count:
 //	> 0 - duration specified
@@ -173,11 +173,7 @@ extern "C"
 
 //*	not done yet
 //************************************************************************
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_TIMER_1_VECTOR),interrupt(IPL3SRS))) Timer1Handler(void)
-#else
-void __attribute__((interrupt(),nomips16)) Timer1Handler(void)
-#endif
+void __USER_ISR Timer1Handler(void)
 {
 
 	if (timer1_toggle_count != 0)

--- a/pic32/cores/pic32/wiring.c
+++ b/pic32/cores/pic32/wiring.c
@@ -70,7 +70,7 @@ extern const uint32_t _verMPIDE_Stub;
 const uint32_t __attribute__((section(".mpide_version"))) _verMPIDE_Stub = MPIDEVER;    // assigns the build number in the header section in the image
 
 // core timer ISR
-void __attribute__((interrupt(),nomips16)) CoreTimerHandler(void);
+void __USER_ISR CoreTimerHandler(void);
 
 //************************************************************************
 //*	globals
@@ -720,11 +720,7 @@ uint32_t millisecondCoreTimerService(uint32_t curTime)
 **      the real compare value to be interrupted to notify the Serivces when count hits that value.
 **
 */
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16, at_vector(_CORE_TIMER_VECTOR),interrupt(IPL7SRS))) CoreTimerHandler(void)
-#else
-void __attribute__((interrupt(),nomips16)) CoreTimerHandler(void)
-#endif
+void __USER_ISR CoreTimerHandler(void)
 {
     uint32_t curTime;
     uint32_t compare;

--- a/pic32/libraries/DSPI/DSPI.cpp
+++ b/pic32/libraries/DSPI/DSPI.cpp
@@ -54,10 +54,10 @@
 /* ------------------------------------------------------------ */
 /*				Forward references to int handlers              */
 /* ------------------------------------------------------------ */
-extern "C" void __attribute__((interrupt(),nomips16)) IntDspi0Handler(void);
-extern "C" void __attribute__((interrupt(),nomips16)) IntDspi1Handler(void);
-extern "C" void __attribute__((interrupt(),nomips16)) IntDspi2Handler(void);
-extern "C" void __attribute__((interrupt(),nomips16)) IntDspi3Handler(void);
+extern "C" void __USER_ISR IntDspi0Handler(void);
+extern "C" void __USER_ISR IntDspi1Handler(void);
+extern "C" void __USER_ISR IntDspi2Handler(void);
+extern "C" void __USER_ISR IntDspi3Handler(void);
 
 /* ------------------------------------------------------------ */
 /*				Local Type and Constant Definitions				*/
@@ -1403,12 +1403,7 @@ extern "C" {
 **		logical SPI port DSPI0
 */
 #if defined(_DSPI0_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DSPI0_VECTOR),interrupt(_DSPI0_IPL_ISR))) IntDspi0Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntDspi0Handler(void)
-#endif
+void __USER_ISR IntDspi0Handler(void)
 {
 	if (pdspi0 != 0) {
 		pdspi0->doDspiInterrupt();
@@ -1433,12 +1428,7 @@ void __attribute__((interrupt(), nomips16)) IntDspi0Handler(void)
 **		logical SPI port DSPI1
 */
 #if defined(_DSPI1_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DSPI1_VECTOR),interrupt(_DSPI1_IPL_ISR))) IntDspi1Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntDspi1Handler(void)
-#endif
+void __USER_ISR IntDspi1Handler(void)
 {
 	if (pdspi1 != 0) {
 		pdspi1->doDspiInterrupt();
@@ -1463,12 +1453,7 @@ void __attribute__((interrupt(), nomips16)) IntDspi1Handler(void)
 **		logical SPI port DSPI2
 */
 #if defined(_DSPI2_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DSPI2_VECTOR),interrupt(_DSPI2_IPL_ISR))) IntDspi2Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntDspi2Handler(void)
-#endif
+void __USER_ISR IntDspi2Handler(void)
 {
 	if (pdspi2 != 0) {
 		pdspi2->doDspiInterrupt();
@@ -1493,12 +1478,7 @@ void __attribute__((interrupt(), nomips16)) IntDspi2Handler(void)
 **		logical SPI port DSPI3
 */
 #if defined(_DSPI3_VECTOR)
-
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DSPI3_VECTOR),interrupt(_DSPI3_IPL_ISR))) IntDspi3Handler(void)
-#else
-void __attribute__((interrupt(), nomips16)) IntDspi3Handler(void)
-#endif
+void __USER_ISR IntDspi3Handler(void)
 {
 	if (pdspi3 != 0) {
 		pdspi3->doDspiInterrupt();

--- a/pic32/libraries/DSPI/DSPI.h
+++ b/pic32/libraries/DSPI/DSPI.h
@@ -73,10 +73,10 @@
 ** method doDspiInterrupt
 */
 extern "C" {
-	void __attribute__((nomips16)) IntDspi0Handler(void);
-	void __attribute__((nomips16)) IntDspi1Handler(void);
-	void __attribute__((nomips16)) IntDspi2Handler(void);
-	void __attribute__((nomips16)) IntDspi3Handler(void);
+	void __USER_ISR IntDspi0Handler(void);
+	void __USER_ISR IntDspi1Handler(void);
+	void __USER_ISR IntDspi2Handler(void);
+	void __USER_ISR IntDspi3Handler(void);
 };
 
 /* ------------------------------------------------------------ */
@@ -109,10 +109,10 @@ class DGSPI
 
 class DSPI : public DGSPI {
 
-	friend		void __attribute__((nomips16)) IntDspi0Handler(void);
-	friend		void __attribute__((nomips16)) IntDspi1Handler(void);
-	friend		void __attribute__((nomips16)) IntDspi2Handler(void);
-	friend		void __attribute__((nomips16)) IntDspi3Handler(void);
+	friend		void __USER_ISR IntDspi0Handler(void);
+	friend		void __USER_ISR IntDspi1Handler(void);
+	friend		void __USER_ISR IntDspi2Handler(void);
+	friend		void __USER_ISR IntDspi3Handler(void);
 
 private:
 	p32_regset *		pregIfs;	//pointer to interrupt flag register

--- a/pic32/libraries/DTWI/DTWI.cpp
+++ b/pic32/libraries/DTWI/DTWI.cpp
@@ -1446,11 +1446,7 @@ DTWI0::DTWI0() : DTWI(((p32_i2c *) _DTWI0_BASE), _DTWI0_BUS_IRQ, _DTWI0_VECTOR, 
 };
 
 // the associated interrupt routine.
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DTWI0_VECTOR),interrupt(_DTWI0_IPL_ISR))) IntDtwi0Handler(void)
-#else
-void __attribute__((interrupt(),nomips16)) IntDtwi0Handler(void)
-#endif
+void __USER_ISR IntDtwi0Handler(void)
 {
     DTWI0::pDTWI0->stateMachine();
 }
@@ -1471,11 +1467,7 @@ DTWI1::DTWI1() : DTWI(((p32_i2c *) _DTWI1_BASE), _DTWI1_BUS_IRQ, _DTWI1_VECTOR, 
 };
 
 // the associated interrupt routine.
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DTWI1_VECTOR),interrupt(_DTWI1_IPL_ISR))) IntDtwi1Handler(void)
-#else
-void __attribute__((interrupt(),nomips16)) IntDtwi1Handler(void)
-#endif
+void __USER_ISR IntDtwi1Handler(void)
 {
     DTWI1::pDTWI1->stateMachine();
 }
@@ -1496,11 +1488,7 @@ DTWI2::DTWI2() : DTWI(((p32_i2c *) _DTWI2_BASE), _DTWI2_BUS_IRQ, _DTWI2_VECTOR, 
 };
 
 // the associated interrupt routine.
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DTWI2_VECTOR),interrupt(_DTWI2_IPL_ISR))) IntDtwi2Handler(void)
-#else
-void __attribute__((interrupt(),nomips16)) IntDtwi2Handler(void)
-#endif
+void __USER_ISR IntDtwi2Handler(void)
 {
     DTWI2::pDTWI2->stateMachine();
 }
@@ -1521,11 +1509,7 @@ DTWI3::DTWI3() : DTWI(((p32_i2c *) _DTWI3_BASE), _DTWI3_BUS_IRQ, _DTWI3_VECTOR, 
 };
 
 // the associated interrupt routine.
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DTWI3_VECTOR),interrupt(_DTWI3_IPL_ISR))) IntDtwi3Handler(void)
-#else
-void __attribute__((interrupt(),nomips16)) IntDtwi3Handler(void)
-#endif
+void __USER_ISR IntDtwi3Handler(void)
 {
     DTWI3::pDTWI3->stateMachine();
 }
@@ -1546,11 +1530,7 @@ DTWI4::DTWI4() : DTWI(((p32_i2c *) _DTWI4_BASE), _DTWI4_BUS_IRQ, _DTWI4_VECTOR, 
 };
 
 // the associated interrupt routine.
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_DTWI4_VECTOR),interrupt(_DTWI4_IPL_ISR))) IntDtwi4Handler(void)
-#else
-void __attribute__((interrupt(),nomips16)) IntDtwi4Handler(void)
-#endif
+void __USER_ISR IntDtwi4Handler(void)
 {
     DTWI4::pDTWI4->stateMachine();
 }

--- a/pic32/libraries/DTWI/DTWI.h
+++ b/pic32/libraries/DTWI/DTWI.h
@@ -69,11 +69,11 @@
 */
 #ifdef __cplusplus
 extern "C" {
-	void __attribute__((nomips16)) IntDtwi0Handler(void);
-	void __attribute__((nomips16)) IntDtwi1Handler(void);
-	void __attribute__((nomips16)) IntDtwi2Handler(void);
-	void __attribute__((nomips16)) IntDtwi3Handler(void);
-	void __attribute__((nomips16)) IntDtwi4Handler(void);
+	void __USER_ISR IntDtwi0Handler(void);
+	void __USER_ISR IntDtwi1Handler(void);
+	void __USER_ISR IntDtwi2Handler(void);
+	void __USER_ISR IntDtwi3Handler(void);
+	void __USER_ISR IntDtwi4Handler(void);
 };
 
 /* ------------------------------------------------------------ */
@@ -83,11 +83,11 @@ extern "C" {
 class DTWI {
 
     // needed to call the stateMachine
-    friend void __attribute__((nomips16)) IntDtwi0Handler(void);
-    friend void __attribute__((nomips16)) IntDtwi1Handler(void);
-    friend void __attribute__((nomips16)) IntDtwi2Handler(void);
-    friend void __attribute__((nomips16)) IntDtwi3Handler(void);
-    friend void __attribute__((nomips16)) IntDtwi4Handler(void);
+    friend void __USER_ISR IntDtwi0Handler(void);
+    friend void __USER_ISR IntDtwi1Handler(void);
+    friend void __USER_ISR IntDtwi2Handler(void);
+    friend void __USER_ISR IntDtwi3Handler(void);
+    friend void __USER_ISR IntDtwi4Handler(void);
 
 public:
     uint8_t static const    addrGenCall         = 0;
@@ -261,7 +261,7 @@ public:
 class DTWI0 : public DTWI {
 
     // needed to get to pDTWI
-    friend void __attribute__((nomips16)) IntDtwi0Handler(void);
+    friend void __USER_ISR IntDtwi0Handler(void);
 
 private:
     static DTWI0 * pDTWI0;
@@ -273,7 +273,7 @@ public:
 class DTWI1 : public DTWI {
 
     // needed to get to pDTWI
-    friend void __attribute__((nomips16)) IntDtwi1Handler(void);
+    friend void __USER_ISR IntDtwi1Handler(void);
 
 private:
     static DTWI1 * pDTWI1;
@@ -285,7 +285,7 @@ public:
 class DTWI2 : public DTWI {
 
     // needed to get to pDTWI
-    friend void __attribute__((nomips16)) IntDtwi2Handler(void);
+    friend void __USER_ISR IntDtwi2Handler(void);
 
 private:
     static DTWI2 * pDTWI2;
@@ -297,7 +297,7 @@ public:
 class DTWI3 : public DTWI {
 
     // needed to get to pDTWI
-    friend void __attribute__((nomips16)) IntDtwi3Handler(void);
+    friend void __USER_ISR IntDtwi3Handler(void);
 
 private:
     static DTWI3 * pDTWI3;
@@ -309,7 +309,7 @@ public:
 class DTWI4 : public DTWI {
 
     // needed to get to pDTWI
-    friend void __attribute__((nomips16)) IntDtwi4Handler(void);
+    friend void __USER_ISR IntDtwi4Handler(void);
 
 private:
     static DTWI4 * pDTWI4;

--- a/pic32/libraries/MRF24G/MRF24GAdaptor.h
+++ b/pic32/libraries/MRF24G/MRF24GAdaptor.h
@@ -54,6 +54,8 @@
 #ifndef MRF24GADAPTOR_H
 #define	MRF24GADAPTOR_H
 
+#include <wiring.h>
+
 #ifdef	__cplusplus
 extern "C" {
 #endif
@@ -199,7 +201,7 @@ typedef struct WFMRFD_T
     WFMRFP  priv;
 } WFMRFD;
 
-void __attribute__((interrupt(),nomips16)) _WFInterrupt(void);
+void __USER_ISR _WFInterrupt(void);
 const NWADP * GetMRF24GAdaptor(MACADDR *pUseThisMac, HRRHEAP hAdpHeap, IPSTATUS * pStatus);
 const NWWF *  GetMRF24WF(void);
 const WFMRF * GetMRF24GFunc(void);

--- a/pic32/libraries/MRF24G/utility/wf_eint_stub.c
+++ b/pic32/libraries/MRF24G/utility/wf_eint_stub.c
@@ -238,11 +238,7 @@ bool WF_isEintPending(void)
   Remarks:
     None
 *****************************************************************************/
-#if defined(__PIC32MZXX__)
-void __attribute((interrupt(WF_IPL_ISR), at_vector(WF_INT_VEC), nomips16)) _WFInterrupt(void)
-#else
-void __attribute((interrupt(WF_IPL_ISR), vector(WF_INT_VEC), nomips16)) _WFInterrupt(void)
-#endif
+void __USER_ISR _WFInterrupt(void)
 {
     // clear EINT
     WIFI_IFSxCLR = WIFI_INT_MASK;        // clear the interrupt

--- a/pic32/libraries/Servo/utility/int.c
+++ b/pic32/libraries/Servo/utility/int.c
@@ -47,32 +47,20 @@
 //  currently existing PIC32 devices, but this needs to be rewritten to be
 //	more generic.
 
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_TIMER_3_VECTOR),interrupt(IPL4SRS))) T3_IntHandler(void)
-#else
-void __attribute__((interrupt(),nomips16)) T3_IntHandler (void)
-#endif
+void __USER_ISR T3_IntHandler (void)
 {
  	handle_interrupts(TIMER3, &TMR3, &PR3); 
 	IFS0bits.T3IF = 0; // Clear timer interrupt status flag
 }
 
 
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_TIMER_4_VECTOR),interrupt(IPL4SRS))) T4_IntHandler(void)
-#else
-void __attribute__((interrupt(),nomips16)) T4_IntHandler (void)
-#endif
+void __USER_ISR T4_IntHandler (void)
 {
  	handle_interrupts(TIMER4, &TMR4, &PR4); 
 	IFS0bits.T4IF = 0; // Clear timer interrupt status flag
 }
 
-#if defined(__PIC32MZXX__)
-void __attribute__((nomips16,at_vector(_TIMER_5_VECTOR),interrupt(IPL4SRS))) T5_IntHandler(void)
-#else
-void __attribute__((interrupt(),nomips16)) T5_IntHandler (void)
-#endif
+void __USER_ISR T5_IntHandler (void)
 {
  	handle_interrupts(TIMER5, &TMR5, &PR5); 
 	IFS0bits.T5IF = 0; // Clear timer interrupt status flag

--- a/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/pic32/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -213,7 +213,7 @@ SoftwareSerial::~SoftwareSerial()
  /*
  * ISR function called whenever any Change Notification pins change state.
  */
-void __attribute__((interrupt)) ChangeNotificationISR() 
+void __USER_ISR ChangeNotificationISR() 
 {
 DEBUG5_HIGH
     // Call the static function that handles all of the CN logic, pass in the current time


### PR DESCRIPTION
* This is going to need some thorough testing on various platforms.

Pretty much all instances of interrupts in the core and libraries had manual `__attribute__` based interrupt stubs. These all lacked the `section` attribute (for MZ boards) to force the interrupt into an addressable area, so large blobs of rodata could shift ISRs into an unusable area causing the chip to crash horribly.

Switching them all to use the macro `__USER_ISR` ensures that they all have the right section added when needed.

Affected:

* Main core (serial, USB, Tone, core timer)
* DSPI
* DTWI
* MRF24G WiFi
* Servo
* SoftwareSerial (broken on the MZ anyway - needs replacing with something new [Brian?])
