### PR TITLE
Implement Print::availableForWrite

### DIFF
--- a/pic32/cores/pic32/HardwareSerial.cpp
+++ b/pic32/cores/pic32/HardwareSerial.cpp
@@ -624,6 +624,16 @@ size_t HardwareSerial::write(uint8_t theChar)
     return 1;
 }
 
+// Hardware serial has a buffer of length 1
+int HardwareSerial::availableForWrite() {
+    if (uart->uxSta.reg & (1 << _UARTSTA_UTXBF)) {
+        return 0;
+    }
+    else {
+        return 1;
+    }
+}
+
 // Hardware serial is always connected regardless.
 HardwareSerial::operator int() {
     return 1;

--- a/pic32/cores/pic32/HardwareSerial.h
+++ b/pic32/cores/pic32/HardwareSerial.h
@@ -122,6 +122,7 @@ class HardwareSerial : public Stream
         void            begin(unsigned long baudRate, uint8_t address);
 		void			end();
 		virtual int		available(void);
+        virtual int     availableForWrite();
 		virtual int		peek();
 		virtual int		read(void);
 		virtual void	flush(void);

--- a/pic32/cores/pic32/Print.h
+++ b/pic32/cores/pic32/Print.h
@@ -42,10 +42,10 @@ class Print
     void setWriteError(int err = 1) { write_error = err; }
   public:
     Print() : write_error(0) {}
-  
+
     int getWriteError() { return write_error; }
     void clearWriteError() { setWriteError(0); }
-  
+
     virtual size_t write(uint8_t) = 0;
     size_t write(const char *str) {
       if (str == NULL) return 0;
@@ -55,7 +55,11 @@ class Print
     size_t write(const char *buffer, size_t size) {
       return write((const uint8_t *)buffer, size);
     }
-    
+
+    // default to zero, meaning "a single write may block"
+    // should be overriden by subclasses with buffering
+    virtual int availableForWrite() { return 0; }
+
     size_t print(const __FlashStringHelper *);
     size_t print(const String &);
     size_t print(const char[]);


### PR DESCRIPTION
This was added in arduino/Arduino#5789

Not implemented yet for USB serial, as that is harder.

That shouldn't stop this patch being merged though - without this change, some Arduino code won't even compile.