### PR TITLE
Added linker scripts for MX695 to core

### DIFF
--- a/pic32/cores/pic32/chipKIT-application-32MX695F512-nobootloader.ld
+++ b/pic32/cores/pic32/chipKIT-application-32MX695F512-nobootloader.ld
@@ -1,0 +1,171 @@
+/* Default linker script, for normal executables */
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
+ENTRY(_reset)
+/*
+ * Provide for a minimum stack and heap size
+ * - _min_stack_size -/* Default linker script, for normal executables */
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
+ENTRY(_reset)
+/*
+ * Provide for a minimum stack and heap size
+ * - _min_stack_size - represents the minimum space that must be made
+ *                     available for the stack.  Can be overridden from
+ *                     the command line using the linker's --defsym option.
+ * - _min_heap_size  - represents the minimum space that must be made
+ *                     available for the heap.  Can be overridden from
+ *                     the command line using the linker's --defsym option.
+ */
+EXTERN (_min_stack_size _min_heap_size)
+PROVIDE(_min_stack_size = 0x800) ;
+PROVIDE(_min_heap_size = 0x800) ;
+
+/*************************************************************************
+ * Processor-specific object file.  Contains SFR definitions.
+ *************************************************************************/
+INPUT("processor.o")
+
+/*************************************************************************
+ * Memory Regions
+ *
+ * Memory regions without attributes cannot be used for orphaned sections.
+ * Only sections specifically assigned to these regions can be allocated
+ * into these regions.
+ *************************************************************************/
+MEMORY
+{
+  exception_mem              : ORIGIN = 0x9D000000, LENGTH = 0x1000
+  kseg0_program_mem    (rx)  : ORIGIN = 0x9D001000, LENGTH = 0x7E000
+  kseg0_eeprom_mem           : ORIGIN = 0x9D07F000, LENGTH = 0x1000
+  kseg0_boot_mem             : ORIGIN = 0x9FC00490, LENGTH = 0x970
+  kseg1_boot_mem             : ORIGIN = 0xBFC00000, LENGTH = 0x490
+  debug_exec_mem             : ORIGIN = 0xBFC02000, LENGTH = 0xFF0 
+  config3                    : ORIGIN = 0xBFC02FF0, LENGTH = 4 
+  config2                    : ORIGIN = 0xBFC02FF4, LENGTH = 4
+  config1                    : ORIGIN = 0xBFC02FF8, LENGTH = 4
+  config0                    : ORIGIN = 0xBFC02FFC, LENGTH = 4
+  kseg1_data_mem       (w!x) : ORIGIN = 0xA0000000, LENGTH = 0x20000
+  sfrs                       : ORIGIN = 0xBF800000, LENGTH = 0x100000
+  configsfrs                 : ORIGIN = 0xBFC02FF0, LENGTH = 0x10
+}
+
+/*************************************************************************
+ * Memory Address Equates
+ *************************************************************************/
+_ebase_address  	    = ORIGIN(exception_mem);
+_IMAGE_PTR_TABLE       	= _ebase_address + 0x0F8;
+_IMAGE_HEADER_ADDR      = _ebase_address + 0x0FC;
+_GEN_EXCPT_ADDR         = _ebase_address + 0x180;
+_RESET_ADDR             = ORIGIN(kseg1_boot_mem);
+_EEPROM_ADDR            = ORIGIN(kseg0_eeprom_mem);
+_BEV_EXCPT_ADDR         = 0xBFC00380;
+_DBG_EXCPT_ADDR         = 0xBFC00480;
+_DBG_CODE_ADDR          = ORIGIN(debug_exec_mem);
+
+/*************************************************************************
+ *  Bootloader program directives.
+ *  
+ * _IMAGE_TYPE
+ *
+ *  image type:
+ */
+     
+_imageReserved                      = 0x00000000 ;
+_imageMPIDE                         = 0x00000001 ;  /* This is a normal MPIDE sketch                                                                                                    */
+_imageBootFlashBootloader           = 0x00000002 ;  /* This is a boot flash bootloader                                                                                                  */
+_imageProgramFlashBootloader        = 0x00000004 ;  /* This is a program flash bootloader                                                                                               */
+_imageSplitFlashBootloader          = 0x00000008 ;  /* This has bootloader code in both boot and program flash                                                                          */
+
+ /*
+ *  Instructions for the bootloader
+ */
+                                                                       
+_imageFullFlashEraseLess4KEEProm    = 0x00010000 ;  /* The original bootloader method of erasing all of program flash except the last 4K reserved for eeprom                            */
+_imageJustInTimeFlashErase          = 0x00020000 ;  /* Only flash pages written too needed by the sketch is erased                                                                      */
+_imageLinkerSpecifiedFlashErase     = 0x00040000 ;  /* The linker defines the flash range to erase                                                                                      */
+_imageFullFlashErase                = 0x00080000 ;  /* All of flash is erased                                                                                                           */
+_imageExecutionJumpAddress          = 0x01000000 ;  /* the bootloader will jump to the execution jump address immediately after programming                                             */
+_imageExecutionJumpToFirstInFlash   = 0x02000000 ;  /* the bootloader will jump to the first sketch loaded in flash ignoring the execution jump address immediately after programming   */
+ 
+/*  
+ * _IMAGE_FLASH_SIZE 
+ *
+ *      Typically _imageJustInTimeFlashErase is selected to just erase the pages
+ *      of flash that code is written too; thus leaving all other flash pages untouched.
+ *  
+ *      If _imageLinkerSpecifiedFlashErase set, then the range
+ *      starting from _ebase_address for _IMAGE_FLASH_SIZE bytes are erased.
+ *
+ *      If _imageFullFlashErase is specified, than the whole flash
+ *      as known by the bootloader will be erased. This will erase eeprom as well
+ *
+ *      if _imageFullFlashEraseLess4KEEProm is set, all of flash less the last 4K is
+ *      erased, this is the old default. This bit could be set to make a program flash bootloader
+ *      erasing everything but the old flash. If NOTHING is set, this will be the default as this is the old behavior.
+ *  
+ *  _JUMP_ADDR
+ *  
+ *      This is the address that the bootloader will jump to start execution
+ *      of the sketch. This is almost always _RESET_ADDR.
+ *
+ *      However, you can specify an alternate entry execution point for example
+ *      if you have alternate starup code that, say, shared
+ *      the runtime with other sketches or needed some kind of specific handling
+ *
+ *      Immediately after programming (avrdude upload) the bootloader will typically
+ *      jump to the just loaded sketch, no matter where it was loaded in flash.
+ *      _imageExecutionJumpToFirstInFlash will tell the bootloader to jump to the first
+ *      sketch in flash even if the just loaded one is not at the beginning of flash.
+ *      This is useful when programming sketches in slots of flash and then always
+ *      jumping to the program-flash loader (vector sketch) as if the board was just reset.
+ *      This bit does not effect jumping to a sketch already in flash after reset.
+ *      As of today, after reset, the first program in flash will always be jumped to.
+ *
+ *************************************************************************/
+ _IMAGE_TYPE            = _imageMPIDE | _imageJustInTimeFlashErase | _imageExecutionJumpAddress;
+ _IMAGE_FLASH_SIZE      = LENGTH(exception_mem) + LENGTH(kseg0_program_mem);
+_JUMP_ADDR              = _RESET_ADDR;
+
+SECTIONS
+{
+  .config_BFC02FF0 : {
+    LONG(0x3AFFFFFF)
+  } > config3
+  .config_BFC02FF4 : {
+    LONG(0xFFF879D9)
+  } > config2
+  .config_BFC02FF8 : {
+    LONG(0xFF6ACD5B)
+  } > config1
+  .config_BFC02FFC : {
+    LONG(0x7FFFFFFE)
+  } > config0
+}
+
+SECTIONS
+{
+  .bev_excpt _BEV_EXCPT_ADDR :
+  {
+    KEEP(*(.bev_handler))
+  } > kseg1_boot_mem
+
+  .dbg_excpt _DBG_EXCPT_ADDR (NOLOAD) :
+  {
+    . += (DEFINED (_DEBUGGER) ? 0x8 : 0x0);
+  } > kseg1_boot_mem
+
+  .dbg_code _DBG_CODE_ADDR (NOLOAD) :
+  {
+    . += (DEFINED (_DEBUGGER) ? LENGTH(debug_exec_mem) : 0x0);
+  } > debug_exec_mem
+
+  /* Boot Sections */
+  .reset _RESET_ADDR :
+  {
+    KEEP(*(.reset))
+  } > kseg1_boot_mem
+}
+
+/* From here out every linker script is the same, so just include it */
+/*INCLUDE "chipKIT-application-COMMON.ld"*/

--- a/pic32/cores/pic32/chipKIT-application-32MX695F512.ld
+++ b/pic32/cores/pic32/chipKIT-application-32MX695F512.ld
@@ -1,0 +1,136 @@
+/* Default linker script, for normal executables */
+OUTPUT_FORMAT("elf32-tradlittlemips")
+OUTPUT_ARCH(pic32mx)
+ENTRY(_reset)
+/*
+ * Provide for a minimum stack and heap size
+ * - _min_stack_size - represents the minimum space that must be made
+ *                     available for the stack.  Can be overridden from
+ *                     the command line using the linker's --defsym option.
+ * - _min_heap_size  - represents the minimum space that must be made
+ *                     available for the heap.  Can be overridden from
+ *                     the command line using the linker's --defsym option.
+ */
+EXTERN (_min_stack_size _min_heap_size)
+PROVIDE(_min_stack_size = 0x800) ;
+PROVIDE(_min_heap_size = 0x800) ;
+
+/*************************************************************************
+ * Processor-specific object file.  Contains SFR definitions.
+ *************************************************************************/
+INPUT("processor.o")
+OPTIONAL("libmchp_peripheral_32MX695F512L.a")
+
+/*************************************************************************
+ * Memory Regions
+ *
+ * Memory regions without attributes cannot be used for orphaned sections.
+ * Only sections specifically assigned to these regions can be allocated
+ * into these regions.
+ *************************************************************************/
+MEMORY
+{
+  exception_mem              : ORIGIN = 0x9D000000, LENGTH = 0x1000
+  kseg0_program_mem    (rx)  : ORIGIN = 0x9D001000, LENGTH = 0x7E000
+  kseg0_eeprom_mem           : ORIGIN = 0x9D07F000, LENGTH = 0x1000
+  kseg0_boot_mem             : ORIGIN = 0x9FC00490, LENGTH = 0
+  kseg1_boot_mem             : ORIGIN = 0xBFC00000, LENGTH = 0 
+  debug_exec_mem             : ORIGIN = 0xBFC02000, LENGTH = 0
+  config3                    : ORIGIN = 0xBFC02FF0, LENGTH = 4 
+  config2                    : ORIGIN = 0xBFC02FF4, LENGTH = 4
+  config1                    : ORIGIN = 0xBFC02FF8, LENGTH = 4
+  config0                    : ORIGIN = 0xBFC02FFC, LENGTH = 4
+  kseg1_data_mem       (w!x) : ORIGIN = 0xA0000000, LENGTH = 0x20000
+  sfrs                       : ORIGIN = 0xBF800000, LENGTH = 0x100000
+  configsfrs                 : ORIGIN = 0xBFC02FF0, LENGTH = 0x10
+}
+
+/*************************************************************************
+ * Memory Address Equates
+ *************************************************************************/
+_ebase_address  	    = ORIGIN(exception_mem);
+_IMAGE_PTR_TABLE       	= _ebase_address + 0x0F8;
+_IMAGE_HEADER_ADDR      = _ebase_address + 0x0FC;
+_GEN_EXCPT_ADDR         = _ebase_address + 0x180;
+_RESET_ADDR             = ORIGIN(kseg0_program_mem);
+_EEPROM_ADDR            = ORIGIN(kseg0_eeprom_mem);
+_BEV_EXCPT_ADDR         = 0xBFC00380;
+_DBG_EXCPT_ADDR         = 0xBFC00480;
+_DBG_CODE_ADDR          = ORIGIN(debug_exec_mem);
+
+/*************************************************************************
+ *  Bootloader program directives.
+ *  
+ * _IMAGE_TYPE
+ *
+ *  image type:
+ */
+     
+_imageReserved                      = 0x00000000 ;
+_imageMPIDE                         = 0x00000001 ;  /* This is a normal MPIDE sketch                                                                                                    */
+_imageBootFlashBootloader           = 0x00000002 ;  /* This is a boot flash bootloader                                                                                                  */
+_imageProgramFlashBootloader        = 0x00000004 ;  /* This is a program flash bootloader                                                                                               */
+_imageSplitFlashBootloader          = 0x00000008 ;  /* This has bootloader code in both boot and program flash                                                                          */
+
+ /*
+ *  Instructions for the bootloader
+ */
+                                                                       
+_imageFullFlashEraseLess4KEEProm    = 0x00010000 ;  /* The original bootloader method of erasing all of program flash except the last 4K reserved for eeprom                            */
+_imageJustInTimeFlashErase          = 0x00020000 ;  /* Only flash pages written too needed by the sketch is erased                                                                      */
+_imageLinkerSpecifiedFlashErase     = 0x00040000 ;  /* The linker defines the flash range to erase                                                                                      */
+_imageFullFlashErase                = 0x00080000 ;  /* All of flash is erased                                                                                                           */
+_imageExecutionJumpAddress          = 0x01000000 ;  /* the bootloader will jump to the execution jump address immediately after programming                                             */
+_imageExecutionJumpToFirstInFlash   = 0x02000000 ;  /* the bootloader will jump to the first sketch loaded in flash ignoring the execution jump address immediately after programming   */
+ 
+/*  
+ * _IMAGE_FLASH_SIZE 
+ *
+ *      Typically _imageJustInTimeFlashErase is selected to just erase the pages
+ *      of flash that code is written too; thus leaving all other flash pages untouched.
+ *  
+ *      If _imageLinkerSpecifiedFlashErase set, then the range
+ *      starting from _ebase_address for _IMAGE_FLASH_SIZE bytes are erased.
+ *
+ *      If _imageFullFlashErase is specified, than the whole flash
+ *      as known by the bootloader will be erased. This will erase eeprom as well
+ *
+ *      if _imageFullFlashEraseLess4KEEProm is set, all of flash less the last 4K is
+ *      erased, this is the old default. This bit could be set to make a program flash bootloader
+ *      erasing everything but the old flash. If NOTHING is set, this will be the default as this is the old behavior.
+ *  
+ *  _JUMP_ADDR
+ *  
+ *      This is the address that the bootloader will jump to start execution
+ *      of the sketch. This is almost always _RESET_ADDR.
+ *
+ *      However, you can specify an alternate entry execution point for example
+ *      if you have alternate starup code that, say, shared
+ *      the runtime with other sketches or needed some kind of specific handling
+ *
+ *      Immediately after programming (avrdude upload) the bootloader will typically
+ *      jump to the just loaded sketch, no matter where it was loaded in flash.
+ *      _imageExecutionJumpToFirstInFlash will tell the bootloader to jump to the first
+ *      sketch in flash even if the just loaded one is not at the beginning of flash.
+ *      This is useful when programming sketches in slots of flash and then always
+ *      jumping to the program-flash loader (vector sketch) as if the board was just reset.
+ *      This bit does not effect jumping to a sketch already in flash after reset.
+ *      As of today, after reset, the first program in flash will always be jumped to.
+ *
+ *************************************************************************/
+ _IMAGE_TYPE            = _imageMPIDE | _imageJustInTimeFlashErase | _imageExecutionJumpAddress;
+ _IMAGE_FLASH_SIZE      = LENGTH(exception_mem) + LENGTH(kseg0_program_mem);
+ _JUMP_ADDR             = _RESET_ADDR;
+
+SECTIONS
+{
+  /* Boot Sections */
+  .reset _RESET_ADDR :
+  {
+    KEEP(*(.reset))
+  } > kseg0_program_mem
+}
+
+/* From here out every linker script is the same, so just include it */
+/*INCLUDE "chipKIT-application-COMMON.ld"*/
+


### PR DESCRIPTION
These are just direct copies of the MX795 files, since the MX695 is just an MX795 without an ethernet port.