### PR TITLE
fixed Wire.read() return type and return value when no data in buffer

### DIFF
--- a/pic32/libraries/DTWI/DTWI.cpp
+++ b/pic32/libraries/DTWI/DTWI.cpp
@@ -113,6 +113,8 @@ DTWI::DTWI(p32_i2c * ptwiC, uint8_t irqBusC, uint8_t vecC, isrFunc vecP, uint8_t
     // and set the priorities for the other 2 vectors.
     setIntPriority(vec+1, ipl, spl);
     setIntPriority(vec+2, ipl, spl);
+#else
+    (void) vecP; // eliminated warning for unused parameter vecP
 #endif
 
     // calculated values

--- a/pic32/libraries/Wire/Wire.cpp
+++ b/pic32/libraries/Wire/Wire.cpp
@@ -320,23 +320,34 @@ uint8_t TwoWire::available(void)
   return (di2c.available());
 }
 
-uint8_t TwoWire::receive(void) {
-	return(read());
+// receive() is pre Arduino 1.x
+// receive returns '\0' (null) when there is no data
+uint8_t TwoWire::receive(void)
+{
+    int value;
+
+    value = read();
+    if(value < 0)
+        return('\0');
+
+    return((uint8_t)value);
 }
 
+// read() is Arduino 1.x 
+// read returns < 0 when there is no data
 // must be called in:
 // slave rx event callback
 // or after requestFrom(address, numBytes)
-uint8_t TwoWire::read(void)
+int TwoWire::read(void)
 {
     byte    data;
   
     if(di2c.read(&data, 1) == 1)
     {
-        return((uint8_t) data);
-  }
+        return((int) ((uint8_t) data));
+    }
 
-	return('\0');
+    return(-1);
 }
 
 // behind the scenes function that is called when data is received

--- a/pic32/libraries/Wire/Wire.h
+++ b/pic32/libraries/Wire/Wire.h
@@ -107,7 +107,7 @@ class TwoWire
     int write(char*);
     uint8_t available(void);
     uint8_t __attribute__((deprecated("Use read() instead"))) receive(void);
-    uint8_t read(void);
+    int read(void);
     void onReceive( void (*)(int) );
     void onRequest( void (*)(void) );
 };


### PR DESCRIPTION
This PR corrects the return type from Wire.read() to be **int** instead of **uint8_t**
The patch is not as simple as it would seem as what is returned from the Arduino pre 1.x function receive() is not the same as as the Arduino 1.x read()
This code preserves receive() behavior and corrects read() type and behavior.

While this code does correct the type and return value from read(), there is a potential that some existing might break if it was depending on current type and behavior of read().
Unfortunately, there is now way to do both:

- correct the return type and return value
- preserve existing return type and existing behavior

There is also a non code changing tweak to DTWI.cpp to remove an unused parameter warning.
