### PR TITLE
allow a sketch access to these two bits DTR and RTS then

### DIFF
--- a/pic32/cores/pic32/USB.h
+++ b/pic32/cores/pic32/USB.h
@@ -417,6 +417,10 @@ class CDCACM : public USBDevice, public Stream {
         bool onOutPacket(uint8_t ep, uint8_t target, uint8_t *data, uint32_t l);
         void onEnumerated();
 
+        int getLineState() { return _lineState; }
+        bool getDTR() { return ((_lineState & 0x01) == 0x01); }
+        bool getRTS() { return ((_lineState & 0x02) == 0x02); }
+
         size_t write(uint8_t);
         size_t write(const uint8_t *b, size_t len);
 


### PR DESCRIPTION
allow a sketch access to these two bits DTR and RTS then
see chipkit.net forum post
http://chipkit.net/forum/viewtopic.php?f=19&t=3839  

arduino code example:
=============

```
#include <Arduino.h>
#include "USB.h"

#define LED_DTR 24 // RA8 
#define LED_RTS 27 // RA9 

USBFS usbDriver;
USBManager USB(usbDriver, 0x0403, 0xA662);

CDCACM usbSerialPort;

void setup() {

	// PINS as Output
	pinMode(LED_DTR,OUTPUT);
	pinMode(LED_RTS,OUTPUT);

	// pins set 0
	digitalWrite(LED_DTR,0);
	digitalWrite(LED_RTS,0);

	USB.addDevice(usbSerialPort);
	USB.begin();
}

void loop() {

	// Testcase
	usbSerialPort.print("\r"); // start allways in the same line
	// usbSerialPort.print("_Line Status is: ");
	usbSerialPort.print(usbSerialPort.getLineState());
        usbSerialPort.print("\r"); // simple return

	if (usbSerialPort.getRTS()==true) {
		digitalWrite(LED_RTS,1);
	}

	if (usbSerialPort.getRTS()!=true) {
		digitalWrite(LED_RTS,0);
	}


	if (usbSerialPort.getDTR()==true) {
		digitalWrite(LED_DTR,1);
	}

	if (usbSerialPort.getDTR()!=true) {
		digitalWrite(LED_DTR,0);
	}
}
```