### PR TITLE
Fix default USB VID

### DIFF
--- a/pic32/cores/pic32/USB.cpp
+++ b/pic32/cores/pic32/USB.cpp
@@ -85,7 +85,7 @@ USBFS usbDriver;
 
 #if defined(__USB_CDCACM_KM__)
     #ifndef _USB_VID_
-        #define _USB_VID_ VID_MICROCHIP
+        #define _USB_VID_ VID_MCHP
     #endif
     #ifndef _USB_PID_
         #define _USB_PID_ PID_CDCACM_KM


### PR DESCRIPTION
Change MICROCHIP to MCHP for the default VID for UART+K+M mode.