### PR TITLE
Cleaned up warnings in DFATFS

### DIFF
--- a/pic32/libraries/DFATFS/DFATFS.h
+++ b/pic32/libraries/DFATFS/DFATFS.h
@@ -136,7 +136,7 @@ public:
     size_t write(uint8_t c) { return fsputc(c); }
     int read() { uint32_t r; char c; fsread(&c, 1, &r); return c; }
     int available() { return fssize() - fstell(); }
-    int peek() { uint32_t pos = fstell(); char c = read(); fslseek(pos); }
+    int peek() { uint32_t pos = fstell(); int c = read(); fslseek(pos); return c;}
     void flush() { fssync(); }
 
     int fsputc (char c);										                /* Put a character to the file */

--- a/pic32/libraries/DFATFS/utility/fs_ff.c
+++ b/pic32/libraries/DFATFS/utility/fs_ff.c
@@ -554,7 +554,7 @@ static const BYTE ExCvt[] = _EXCVT;	/* Upper conversion table for extended chara
 
 ---------------------------------------------------------------------------*/
 
-WCHAR ff_convert (WCHAR wch, UINT dir)
+WCHAR ff_convert (WCHAR wch, UINT __attribute__((unused)) dir)
 {
     if (wch < 0x80) {
         /* ASCII Char */
@@ -1769,8 +1769,6 @@ FRESULT dir_remove (	/* FR_OK: Successful, FR_DISK_ERR: A disk error */
 #endif /* !_FS_READONLY */
 
 
-
-
 /*-----------------------------------------------------------------------*/
 /* Get file information from directory entry                             */
 /*-----------------------------------------------------------------------*/
@@ -1817,7 +1815,6 @@ void get_fileinfo (		/* No return code */
 #if _USE_LFN
 	if (fno->lfname) {
 		WCHAR w, *lfn;
-
 		i = 0; p = fno->lfname;
 		if (dp->sect && fno->lfsize && dp->lfn_idx != 0xFFFF) {	/* Get LFN if available */
 			lfn = dp->lfn;


### PR DESCRIPTION
One unused variable that was correct (suppressed) and one unused variable that highlighted the fact that `DFILE::peek()` was not working at all (it never returned the peeked value...!)