### PR TITLE
Added .romdata section

### DIFF
--- a/pic32/cores/pic32/chipKIT-application-COMMON-MZ.ld
+++ b/pic32/cores/pic32/chipKIT-application-COMMON-MZ.ld
@@ -767,6 +767,19 @@ SECTIONS
     *(.rodata1)
     . = ALIGN(4) ;
   } >kseg0_program_mem
+
+  /*
+   * Place constant variables in this area that you don't want included
+   * in the output. Ideal for big arrays for storing a filesystem that
+   * would take forever to program. Also has the effect that reprogramming
+   * can make the data persistent as long as addresses don't change.
+   */
+  .romdata ALIGN(4) (NOLOAD) :
+  {
+    *(.romdata .romdata.*)
+    . = ALIGN(4) ;
+  } >kseg0_program_mem
+
   /*
    * Small initialized constant global and static data can be placed in the
    * .sdata2 section.  This is different from .sdata, which contains small

--- a/pic32/cores/pic32/chipKIT-application-COMMON.ld
+++ b/pic32/cores/pic32/chipKIT-application-COMMON.ld
@@ -591,6 +591,18 @@ SECTIONS
   } >kseg0_program_mem
 
   /*
+   * Place constant variables in this area that you don't want included
+   * in the output. Ideal for big arrays for storing a filesystem that
+   * would take forever to program. Also has the effect that reprogramming
+   * can make the data persistent as long as addresses don't change.
+   */
+  .romdata ALIGN(4) (NOLOAD) :
+  {
+    *(.romdata .romdata.*)
+    . = ALIGN(4) ;
+  } >kseg0_program_mem
+
+  /*
    * Small initialized constant global and static data can be placed in the
    * .sdata2 section.  This is different from .sdata, which contains small
    * initialized non-constant global and static data.

--- a/pic32/platform.txt
+++ b/pic32/platform.txt
@@ -98,7 +98,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.hex
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"
-recipe.size.regex=^(?:\.reset|\.startup|\.init|\.fini|\.ctors|\.dtors|\.header_info|\.dinit|\.text\S*|\.rodata\S*|\.data)\s+([0-9]+).*
+recipe.size.regex=^(?:\.reset|\.startup|\.init|\.fini|\.ctors|\.dtors|\.header_info|\.dinit|\.text\S*|\.rodata\S*|\.romdata\S*|\.data)\s+([0-9]+).*
 recipe.size.regex.data=^(?:\.dbg_data|\.ram_exchange_data|\.sdata|\.sbss|\.data\S*|\.stack|\.bss\S*|\.eh_frame|\.jcr|\.libc\S*|\.heap)\s+([0-9]+).*
 #recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 


### PR DESCRIPTION
Adds a section to the linker script to contain flash data that you don't want to actively include in the output. Ideal for big flash blocks that will be programmed by the rest of the program, such as flash filesystems. Causes the space to be allocated in the memory map but doesn't actively include the data in the output file.