### PR TITLE
Improved fsmkfs volume ID generation

### DIFF
--- a/pic32/libraries/DFATFS/DFATFS.cpp
+++ b/pic32/libraries/DFATFS/DFATFS.cpp
@@ -263,6 +263,12 @@ FRESULT DFATFS::fsunmount(const char* path)
 
 FRESULT DFATFS::fsmkfs(DFSVOL& dfsVol)
 {
+    uint32_t volid = (rand() & 0x0FFFFFFF) | 0xC0000000;
+    return fsmkfs(dfsVol, volid);
+}
+
+FRESULT DFATFS::fsmkfs(DFSVOL& dfsVol, uint32_t volid)
+{
     FRESULT fr = FR_OK;
     DFSVOL * pDFSVolSave = _arDFSVOL[iMKFS];
 
@@ -276,7 +282,7 @@ FRESULT DFATFS::fsmkfs(DFSVOL& dfsVol)
     }
 
     // create the file system
-    fr = f_mkfs(szFatFsVols[iMKFS], dfsVol._sfd, dfsVol._au);
+    fr = f_mkfs(szFatFsVols[iMKFS], dfsVol._sfd, dfsVol._au, volid);
     // unmount the drive
     fsunmount(szFatFsVols[iMKFS]);
 

--- a/pic32/libraries/DFATFS/DFATFS.h
+++ b/pic32/libraries/DFATFS/DFATFS.h
@@ -208,6 +208,7 @@ public:
     static FRESULT fssetlabel (const char * label);							        /* Set volume label */
     static FRESULT fsmount (DFSVOL& dfsvol, const char * path, uint8_t opt);        /* Mount a logical drive */
     static FRESULT fsunmount(const char* path);                                     /* UnMount the logical drive */
+    static FRESULT fsmkfs (DFSVOL& dfsvol, uint32_t id);                            /* Create a file system on the volume */
     static FRESULT fsmkfs (DFSVOL& dfsvol);				                            /* Create a file system on the volume */
     static bool fsexists(const char * path) { return(DDIRINFO::fsstat(path) == FR_OK); }
 

--- a/pic32/libraries/DFATFS/utility/fs_ff.c
+++ b/pic32/libraries/DFATFS/utility/fs_ff.c
@@ -4017,7 +4017,8 @@ FRESULT f_forward (
 FRESULT f_mkfs (
 	const TCHAR* path,	/* Logical drive number */
 	BYTE sfd,			/* Partitioning rule 0:FDISK, 1:SFD */
-	UINT au				/* Size of allocation unit in unit of byte or sector */
+	UINT au,			/* Size of allocation unit in unit of byte or sector */
+    DWORD volid
 )
 {
 	static const WORD vst[] = { 1024,   512,  256,  128,   64,    32,   16,    8,    4,    2,   0};
@@ -4176,7 +4177,7 @@ FRESULT f_mkfs (
 	ST_WORD(tbl+BPB_SecPerTrk, 63);			/* Number of sectors per track */
 	ST_WORD(tbl+BPB_NumHeads, 255);			/* Number of heads */
 	ST_DWORD(tbl+BPB_HiddSec, b_vol);		/* Hidden sectors */
-	n = GET_FATTIME();						/* Use current time as VSN */
+	n = volid;
 	if (fmt == FS_FAT32) {
 		ST_DWORD(tbl+BS_VolID32, n);		/* VSN */
 		ST_DWORD(tbl+BPB_FATSz32, n_fat);	/* Number of sectors per FAT */

--- a/pic32/libraries/DFATFS/utility/fs_ff.h
+++ b/pic32/libraries/DFATFS/utility/fs_ff.h
@@ -229,7 +229,7 @@ FRESULT f_getfree (const TCHAR* path, DWORD* nclst, FATFS** fatfs);	/* Get numbe
 FRESULT f_getlabel (const TCHAR* path, TCHAR* label, DWORD* vsn);	/* Get volume label */
 FRESULT f_setlabel (const TCHAR* label);							/* Set volume label */
 FRESULT f_mount (FATFS* fs, const TCHAR* path, BYTE opt);			/* Mount/Unmount a logical drive */
-FRESULT f_mkfs (const TCHAR* path, BYTE sfd, UINT au);				/* Create a file system on the volume */
+FRESULT f_mkfs (const TCHAR* path, BYTE sfd, UINT au, DWORD volid);	/* Create a file system on the volume */
 FRESULT f_fdisk (BYTE pdrv, const DWORD szt[], void* work);			/* Divide a physical drive into some partitions */
 int f_putc (TCHAR c, FIL* fp);										/* Put a character to the file */
 int f_puts (const TCHAR* str, FIL* cp);								/* Put a string to the file */


### PR DESCRIPTION
Added manual setting of volume ID when formatting. If not specified a random volume ID starting with 0xC (for chipKIT) is generated.