### PR TITLE
Removed USB from OpenBCI 32 and regenerated board menus

### DIFF
--- a/pic32/boards.txt
+++ b/pic32/boards.txt
@@ -500,8 +500,8 @@ openbci.group=chipKIT
 openbci.platform=pic32
 openbci.build.board=_BOARD_DP32_
 
-openbci.usb.enabled=true
-openbci.usb.default=a_cdcacm
+openbci.usb.enabled=false
+openbci.usb.default=z_custom
 
 openbci.ccflags=-Map="map.map"
 openbci.ldscript=chipKIT-application-32MX250F128.ld
@@ -812,41 +812,6 @@ RGB_Station.menu.Frequency.build.f_cpu=48000000L
 ############# Auto generated menu entries below here. ###############
 ############### DO NOT ADD ANYTHING AFTER THIS LINE #################
 
-quick240_usb_pic32.menu.USB.a_cdcacm=Serial
-quick240_usb_pic32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-quick240_usb_pic32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-quick240_usb_pic32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-quick240_usb_pic32.menu.USB.z_custom=Custom / Disabled
-quick240_usb_pic32.menu.USB.z_custom.build.extra_flags=
-
-cui32.menu.USB.a_cdcacm=Serial
-cui32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-cui32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-cui32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-cui32.menu.USB.z_custom=Custom / Disabled
-cui32.menu.USB.z_custom.build.extra_flags=
-
-chipkit_WF32.menu.USB.z_custom=Custom / Disabled
-chipkit_WF32.menu.USB.z_custom.build.extra_flags=
-chipkit_WF32.menu.USB.a_cdcacm=Serial
-chipkit_WF32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-chipkit_WF32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-chipkit_WF32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-
-mega_pic32.menu.USB.z_custom=Custom / Disabled
-mega_pic32.menu.USB.z_custom.build.extra_flags=
-mega_pic32.menu.USB.a_cdcacm=Serial
-mega_pic32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-mega_pic32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-mega_pic32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-
-flipnclickmz.menu.USB.a_cdcacm=Serial
-flipnclickmz.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-flipnclickmz.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-flipnclickmz.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-flipnclickmz.menu.USB.z_custom=Custom / Disabled
-flipnclickmz.menu.USB.z_custom.build.extra_flags=
-
 fubarino_sd.menu.USB.a_cdcacm=Serial
 fubarino_sd.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
 fubarino_sd.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
@@ -854,61 +819,12 @@ fubarino_sd.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDC
 fubarino_sd.menu.USB.z_custom=Custom / Disabled
 fubarino_sd.menu.USB.z_custom.build.extra_flags=
 
-usbono_pic32.menu.USB.a_cdcacm=Serial
-usbono_pic32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-usbono_pic32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-usbono_pic32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-usbono_pic32.menu.USB.z_custom=Custom / Disabled
-usbono_pic32.menu.USB.z_custom.build.extra_flags=
-
-Olimex_Pinguino32.menu.USB.a_cdcacm=Serial
-Olimex_Pinguino32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-Olimex_Pinguino32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-Olimex_Pinguino32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-Olimex_Pinguino32.menu.USB.z_custom=Custom / Disabled
-Olimex_Pinguino32.menu.USB.z_custom.build.extra_flags=
-
-chipkit_DP32.menu.USB.a_cdcacm=Serial
-chipkit_DP32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-chipkit_DP32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-chipkit_DP32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-chipkit_DP32.menu.USB.z_custom=Custom / Disabled
-chipkit_DP32.menu.USB.z_custom.build.extra_flags=
-
-picadillo_35t.menu.USB.z_custom=Custom / Disabled
-picadillo_35t.menu.USB.z_custom.build.extra_flags=
-picadillo_35t.menu.USB.a_cdcacm=Serial
-picadillo_35t.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-picadillo_35t.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-picadillo_35t.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-
-ubw32_mx795.menu.USB.a_cdcacm=Serial
-ubw32_mx795.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-ubw32_mx795.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-ubw32_mx795.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-ubw32_mx795.menu.USB.z_custom=Custom / Disabled
-ubw32_mx795.menu.USB.z_custom.build.extra_flags=
-
-openbci.menu.USB.a_cdcacm=Serial
-openbci.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-openbci.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-openbci.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-openbci.menu.USB.z_custom=Custom / Disabled
-openbci.menu.USB.z_custom.build.extra_flags=
-
-pontech_NoFire.menu.USB.a_cdcacm=Serial
-pontech_NoFire.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-pontech_NoFire.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-pontech_NoFire.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-pontech_NoFire.menu.USB.z_custom=Custom / Disabled
-pontech_NoFire.menu.USB.z_custom.build.extra_flags=
-
-OpenScope.menu.USB.a_cdcacm=Serial
-OpenScope.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-OpenScope.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-OpenScope.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-OpenScope.menu.USB.z_custom=Custom / Disabled
-OpenScope.menu.USB.z_custom.build.extra_flags=
+RGB_Station.menu.USB.a_cdcacm=Serial
+RGB_Station.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+RGB_Station.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+RGB_Station.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+RGB_Station.menu.USB.z_custom=Custom / Disabled
+RGB_Station.menu.USB.z_custom.build.extra_flags=
 
 chipkit_WiFire.menu.USB.z_custom=Custom / Disabled
 chipkit_WiFire.menu.USB.z_custom.build.extra_flags=
@@ -917,26 +833,12 @@ chipkit_WiFire.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDC
 chipkit_WiFire.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
 chipkit_WiFire.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
 
-chipkit_Pi.menu.USB.z_custom=Custom / Disabled
-chipkit_Pi.menu.USB.z_custom.build.extra_flags=
-chipkit_Pi.menu.USB.a_cdcacm=Serial
-chipkit_Pi.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-chipkit_Pi.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-chipkit_Pi.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-
-lenny.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-lenny.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-lenny.menu.USB.a_cdcacm=Serial
-lenny.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-lenny.menu.USB.z_custom=Custom / Disabled
-lenny.menu.USB.z_custom.build.extra_flags=
-
-CUI32stem.menu.USB.a_cdcacm=Serial
-CUI32stem.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-CUI32stem.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-CUI32stem.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-CUI32stem.menu.USB.z_custom=Custom / Disabled
-CUI32stem.menu.USB.z_custom.build.extra_flags=
+chipkit_WF32.menu.USB.z_custom=Custom / Disabled
+chipkit_WF32.menu.USB.z_custom.build.extra_flags=
+chipkit_WF32.menu.USB.a_cdcacm=Serial
+chipkit_WF32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+chipkit_WF32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+chipkit_WF32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
 
 chipkit_pro_mx7.menu.USB.z_custom=Custom / Disabled
 chipkit_pro_mx7.menu.USB.z_custom.build.extra_flags=
@@ -945,19 +847,82 @@ chipkit_pro_mx7.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CD
 chipkit_pro_mx7.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
 chipkit_pro_mx7.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
 
+Olimex_Pinguino32.menu.USB.a_cdcacm=Serial
+Olimex_Pinguino32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+Olimex_Pinguino32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+Olimex_Pinguino32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+Olimex_Pinguino32.menu.USB.z_custom=Custom / Disabled
+Olimex_Pinguino32.menu.USB.z_custom.build.extra_flags=
+
+pontech_NoFire.menu.USB.a_cdcacm=Serial
+pontech_NoFire.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+pontech_NoFire.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+pontech_NoFire.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+pontech_NoFire.menu.USB.z_custom=Custom / Disabled
+pontech_NoFire.menu.USB.z_custom.build.extra_flags=
+
+chipkit_Pi.menu.USB.z_custom=Custom / Disabled
+chipkit_Pi.menu.USB.z_custom.build.extra_flags=
+chipkit_Pi.menu.USB.a_cdcacm=Serial
+chipkit_Pi.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+chipkit_Pi.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+chipkit_Pi.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+
+mega_pic32.menu.USB.z_custom=Custom / Disabled
+mega_pic32.menu.USB.z_custom.build.extra_flags=
+mega_pic32.menu.USB.a_cdcacm=Serial
+mega_pic32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+mega_pic32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+mega_pic32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+
+OpenScope.menu.USB.a_cdcacm=Serial
+OpenScope.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+OpenScope.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+OpenScope.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+OpenScope.menu.USB.z_custom=Custom / Disabled
+OpenScope.menu.USB.z_custom.build.extra_flags=
+
+flipnclickmz.menu.USB.a_cdcacm=Serial
+flipnclickmz.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+flipnclickmz.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+flipnclickmz.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+flipnclickmz.menu.USB.z_custom=Custom / Disabled
+flipnclickmz.menu.USB.z_custom.build.extra_flags=
+
+lenny.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+lenny.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+lenny.menu.USB.a_cdcacm=Serial
+lenny.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+lenny.menu.USB.z_custom=Custom / Disabled
+lenny.menu.USB.z_custom.build.extra_flags=
+
+openbci.menu.USB.z_custom=Custom / Disabled
+openbci.menu.USB.z_custom.build.extra_flags=
+openbci.menu.USB.a_cdcacm=Serial
+openbci.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+openbci.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+openbci.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+
+cui32.menu.USB.a_cdcacm=Serial
+cui32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+cui32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+cui32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+cui32.menu.USB.z_custom=Custom / Disabled
+cui32.menu.USB.z_custom.build.extra_flags=
+
+quick240_usb_pic32.menu.USB.a_cdcacm=Serial
+quick240_usb_pic32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+quick240_usb_pic32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+quick240_usb_pic32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+quick240_usb_pic32.menu.USB.z_custom=Custom / Disabled
+quick240_usb_pic32.menu.USB.z_custom.build.extra_flags=
+
 clicker2.menu.USB.a_cdcacm=Serial
 clicker2.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
 clicker2.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
 clicker2.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
 clicker2.menu.USB.z_custom=Custom / Disabled
 clicker2.menu.USB.z_custom.build.extra_flags=
-
-ubw32_mx460.menu.USB.a_cdcacm=Serial
-ubw32_mx460.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-ubw32_mx460.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-ubw32_mx460.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-ubw32_mx460.menu.USB.z_custom=Custom / Disabled
-ubw32_mx460.menu.USB.z_custom.build.extra_flags=
 
 fubarino_mini.menu.USB.a_cdcacm=Serial
 fubarino_mini.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
@@ -966,9 +931,45 @@ fubarino_mini.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_C
 fubarino_mini.menu.USB.z_custom=Custom / Disabled
 fubarino_mini.menu.USB.z_custom.build.extra_flags=
 
-RGB_Station.menu.USB.a_cdcacm=Serial
-RGB_Station.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
-RGB_Station.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
-RGB_Station.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
-RGB_Station.menu.USB.z_custom=Custom / Disabled
-RGB_Station.menu.USB.z_custom.build.extra_flags=
+ubw32_mx460.menu.USB.a_cdcacm=Serial
+ubw32_mx460.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+ubw32_mx460.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+ubw32_mx460.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+ubw32_mx460.menu.USB.z_custom=Custom / Disabled
+ubw32_mx460.menu.USB.z_custom.build.extra_flags=
+
+ubw32_mx795.menu.USB.a_cdcacm=Serial
+ubw32_mx795.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+ubw32_mx795.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+ubw32_mx795.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+ubw32_mx795.menu.USB.z_custom=Custom / Disabled
+ubw32_mx795.menu.USB.z_custom.build.extra_flags=
+
+picadillo_35t.menu.USB.z_custom=Custom / Disabled
+picadillo_35t.menu.USB.z_custom.build.extra_flags=
+picadillo_35t.menu.USB.a_cdcacm=Serial
+picadillo_35t.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+picadillo_35t.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+picadillo_35t.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+
+usbono_pic32.menu.USB.a_cdcacm=Serial
+usbono_pic32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+usbono_pic32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+usbono_pic32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+usbono_pic32.menu.USB.z_custom=Custom / Disabled
+usbono_pic32.menu.USB.z_custom.build.extra_flags=
+
+CUI32stem.menu.USB.a_cdcacm=Serial
+CUI32stem.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+CUI32stem.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+CUI32stem.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+CUI32stem.menu.USB.z_custom=Custom / Disabled
+CUI32stem.menu.USB.z_custom.build.extra_flags=
+
+chipkit_DP32.menu.USB.a_cdcacm=Serial
+chipkit_DP32.menu.USB.a_cdcacm.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM__ -D__SERIAL_IS_USB__
+chipkit_DP32.menu.USB.b_cdcacm_km=Serial, Keyboard & Mouse
+chipkit_DP32.menu.USB.b_cdcacm_km.build.extra_flags=-D__USB_ENABLED__ -D__USB_CDCACM_KM__ -D__SERIAL_IS_USB__
+chipkit_DP32.menu.USB.z_custom=Custom / Disabled
+chipkit_DP32.menu.USB.z_custom.build.extra_flags=
+

--- a/pic32/variants/openbci/Board_Defs.h
+++ b/pic32/variants/openbci/Board_Defs.h
@@ -59,7 +59,6 @@
 
 // #define	_BOARD_NAME_	"chipKIT DP32"
 #define	_BOARD_NAME_	"OpenBCI 32"
-#define _USB
 
 /* Define the peripherals available on the board.
 */

--- a/pic32/variants/openbci/Board_Defs.h
+++ b/pic32/variants/openbci/Board_Defs.h
@@ -48,6 +48,9 @@
 #if !defined(BOARD_DEFS_H)
 #define BOARD_DEFS_H
 
+// Fix for old incorrect USB enabled renaming serial
+#define Serial0 Serial
+
 #include <inttypes.h>
 
 /* ------------------------------------------------------------ */


### PR DESCRIPTION
The USB pins are used by SPI on this board. Having a default active USB profile (Which is completely pointless) breaks everything.  This patch removes USB support from that board.