### PR TITLE
Added USB string allocation feature

### DIFF
--- a/pic32/cores/pic32/USB.cpp
+++ b/pic32/cores/pic32/USB.cpp
@@ -118,6 +118,7 @@ USBManager::USBManager(USBDriver *driver, uint16_t vid, uint16_t pid, const char
     _pid = pid;
     _ifCount = 0;
     _epCount = 1;
+    _stringCount = 4;
     _manufacturer = mfg;
     _product = prod;
     _deviceAttributes = 0x80; // Bus powered
@@ -140,6 +141,7 @@ USBManager::USBManager(USBDriver &driver, uint16_t vid, uint16_t pid, const char
     _pid = pid;
     _ifCount = 0;
     _epCount = 1;
+    _stringCount = 4;
     _manufacturer = mfg;
     _product = prod;
     if (ser) {
@@ -160,6 +162,7 @@ USBManager::USBManager(USBDriver *driver, uint16_t vid, uint16_t pid) {
     _pid = pid;
     _ifCount = 0;
     _epCount = 1;
+    _stringCount = 4;
     _manufacturer = "chipKIT";
     _product = _BOARD_NAME_;
     _serial = _defSerial;
@@ -175,10 +178,17 @@ USBManager::USBManager(USBDriver &driver, uint16_t vid, uint16_t pid) {
     _pid = pid;
     _ifCount = 0;
     _epCount = 1;
+    _stringCount = 4;
     _manufacturer = "chipKIT";
     _product = _BOARD_NAME_;
     _serial = _defSerial;
     _serialLen = _driver->populateDefaultSerial(_defSerial);
+}
+
+uint8_t USBManager::allocateString() {
+    uint8_t i = _stringCount;
+    _stringCount++;
+    return i;
 }
 
 uint8_t USBManager::allocateInterface() {

--- a/pic32/cores/pic32/USB.h
+++ b/pic32/cores/pic32/USB.h
@@ -248,6 +248,7 @@ class USBManager {
         uint16_t _pid;
         uint8_t _ifCount;
         uint8_t _epCount;
+        uint8_t _stringCount;
         uint8_t _target;
 
         const char *_manufacturer;
@@ -282,6 +283,7 @@ class USBManager {
 
         uint8_t allocateInterface();
         uint8_t allocateEndpoint();
+        uint8_t allocateString();
 
         bool addEndpoint(uint8_t id, uint8_t direction, uint8_t type, uint32_t size, uint8_t *a, uint8_t *b) {
             return _driver->addEndpoint(id, direction, type, size, a, b);


### PR DESCRIPTION
This allows device drivers to request a String Descriptor ID from the manager. USB Ethernet (CDC/ECM) devices store the MAC address in a string descriptor, so each device needs a unique string descriptor ID allocated by the manager to reference it.