### PR TITLE
Reinstated missing E2END

### DIFF
--- a/pic32/cores/pic32/cpudefs.h
+++ b/pic32/cores/pic32/cpudefs.h
@@ -38,6 +38,8 @@
 //************************************************************************
 //*    Microchip pic32 chip names
 
+#define    E2END        0x0fff    //*    4 k of simulated EEPROM
+
 #include "cpudefs_table.h"
 
 // Set up MZ ADC type   


### PR DESCRIPTION
The `E2END` macro got accidentally left out of the new `cpudefs.h` file.  This breaks EEPROM.

Quite why this is in the core and not either in the linker script (where the EEPROM size is defined) or the EEPROM library is anyone's guess - but it is... or was...