### PR TITLE
Manually added retired chips

### DIFF
--- a/pic32/cores/pic32/cpudefs.h
+++ b/pic32/cores/pic32/cpudefs.h
@@ -38,7 +38,8 @@
 //************************************************************************
 //*    Microchip pic32 chip names
 
-#define    E2END        0x0fff    //*    4 k of simulated EEPROM
+    #define    E2END        0x0fff    //*    4 k of simulated EEPROM
+
 
 #include "cpudefs_table.h"
 

--- a/pic32/cores/pic32/cpudefs_retired.h
+++ b/pic32/cores/pic32/cpudefs_retired.h
@@ -1,0 +1,751 @@
+#if defined(__32MZ1024ECG064__)
+    #define _CPU_NAME_      "32MZ1024ECG064"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECH064__)
+    #define _CPU_NAME_      "32MZ1024ECH064"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECM064__)
+    #define _CPU_NAME_      "32MZ1024ECM064"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECG064__)
+    #define _CPU_NAME_      "32MZ2048ECG064"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECH064__)
+    #define _CPU_NAME_      "32MZ2048ECH064"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECM064__)
+    #define _CPU_NAME_      "32MZ2048ECM064"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECG100__)
+    #define _CPU_NAME_      "32MZ1024ECG100"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECH100__)
+    #define _CPU_NAME_      "32MZ1024ECH100"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECM100__)
+    #define _CPU_NAME_      "32MZ1024ECM100"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECG100__)
+    #define _CPU_NAME_      "32MZ2048ECG100"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECH100__)
+    #define _CPU_NAME_      "32MZ2048ECH100"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECM100__)
+    #define _CPU_NAME_      "32MZ2048ECM100"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECG124__)
+    #define _CPU_NAME_      "32MZ1024ECG124"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECH124__)
+    #define _CPU_NAME_      "32MZ1024ECH124"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECM124__)
+    #define _CPU_NAME_      "32MZ1024ECM124"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECG124__)
+    #define _CPU_NAME_      "32MZ2048ECG124"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECH124__)
+    #define _CPU_NAME_      "32MZ2048ECH124"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECM124__)
+    #define _CPU_NAME_      "32MZ2048EC124"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECG144__)
+    #define _CPU_NAME_      "32MZ1024ECG144"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECH144__)
+    #define _CPU_NAME_      "32MZ1024ECH144"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECM144__)
+    #define _CPU_NAME_      "32MZ1024ECM144"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECG144__)
+    #define _CPU_NAME_      "32MZ2048ECG144"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECH144__)
+    #define _CPU_NAME_      "32MZ2048ECH144"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ2048ECM144__)
+    #define _CPU_NAME_      "32MZ2048ECM144"
+    #define FLASHEND        (((2048 - 4) * 1024L) - 1)
+    #define RAMEND          ((512 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECE064__)
+    #define _CPU_NAME_      "32MZ0512ECE064"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECF064__)
+    #define _CPU_NAME_      "32MZ0512ECF064"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECK064__)
+    #define _CPU_NAME_      "32MZ0512ECK064"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECE064__)
+    #define _CPU_NAME_      "32MZ1024ECE064"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECF064__)
+    #define _CPU_NAME_      "32MZ1024ECF064"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECK064__)
+    #define _CPU_NAME_      "32MZ1024ECK064"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  64
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECE100__)
+    #define _CPU_NAME_      "32MZ0512ECE100"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECF100__)
+    #define _CPU_NAME_      "32MZ0512ECF100"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECK100__)
+    #define _CPU_NAME_      "32MZ0512ECK100"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECE100__)
+    #define _CPU_NAME_      "32MZ1024ECE100"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECF100__)
+    #define _CPU_NAME_      "32MZ1024ECF100"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECK100__)
+    #define _CPU_NAME_      "32MZ1024ECK100"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  100
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECE124__)
+    #define _CPU_NAME_      "32MZ0512ECE124"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECF124__)
+    #define _CPU_NAME_      "32MZ0512ECF124"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECE124__)
+    #define _CPU_NAME_      "32MZ1024ECE124"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECF124__)
+    #define _CPU_NAME_      "32MZ1024ECF124"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECK124__)
+    #define _CPU_NAME_      "32MZ1024ECK124"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  124
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECE144__)
+    #define _CPU_NAME_      "32MZ0512ECE144"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECF144__)
+    #define _CPU_NAME_      "32MZ0512ECF144"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ0512ECK144__)
+    #define _CPU_NAME_      "32MZ0512ECK144"
+    #define FLASHEND        (((512 - 4) * 1024L) - 1)
+    #define RAMEND          ((128 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECE144__)
+    #define _CPU_NAME_      "32MZ1024ECE144"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECF144__)
+    #define _CPU_NAME_      "32MZ1024ECF144"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif
+
+#if defined(__32MZ1024ECK144__)
+    #define _CPU_NAME_      "32MZ1024ECK144"
+    #define FLASHEND        (((1024 - 4) * 1024L) - 1)
+    #define RAMEND          ((256 * 1024L) - 1)
+    #define __PIC32_PPS__
+    #define __PIC32_PINS__  144
+    #define __PIC32MZXX__
+    #define __HAS_USB__
+    #define __NUM_USB_MODULES__           1
+    #define __HAS_DMA__
+    #define __NUM_DMA_CHANNELS__          8
+    #define __HAS_ETHERNET__
+    #define __FLASH_ROW__                 512
+    #define __FLASH_PAGE__                4096
+#endif

--- a/pic32/cores/pic32/cpudefs_table.h
+++ b/pic32/cores/pic32/cpudefs_table.h
@@ -12,8 +12,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK0512GPD100__)
+#if defined(__32MK0512GPD100__)
     #define _CPU_NAME_                    "32MK0512GPD100"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -27,8 +28,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK0512GPE064__)
+#if defined(__32MK0512GPE064__)
     #define _CPU_NAME_                    "32MK0512GPE064"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -42,8 +44,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK0512GPE100__)
+#if defined(__32MK0512GPE100__)
     #define _CPU_NAME_                    "32MK0512GPE100"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -57,8 +60,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK0512MCF064__)
+#if defined(__32MK0512MCF064__)
     #define _CPU_NAME_                    "32MK0512MCF064"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -71,8 +75,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK0512MCF100__)
+#if defined(__32MK0512MCF100__)
     #define _CPU_NAME_                    "32MK0512MCF100"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -85,8 +90,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK1024GPD064__)
+#if defined(__32MK1024GPD064__)
     #define _CPU_NAME_                    "32MK1024GPD064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -100,8 +106,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK1024GPD100__)
+#if defined(__32MK1024GPD100__)
     #define _CPU_NAME_                    "32MK1024GPD100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -115,8 +122,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK1024GPE064__)
+#if defined(__32MK1024GPE064__)
     #define _CPU_NAME_                    "32MK1024GPE064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -129,8 +137,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK1024GPE100__)
+#if defined(__32MK1024GPE100__)
     #define _CPU_NAME_                    "32MK1024GPE100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -144,8 +153,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK1024MCF064__)
+#if defined(__32MK1024MCF064__)
     #define _CPU_NAME_                    "32MK1024MCF064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -158,8 +168,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MK1024MCF100__)
+#if defined(__32MK1024MCF100__)
     #define _CPU_NAME_                    "32MK1024MCF100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -172,8 +183,9 @@
     #define __NUM_DMA_CHANNELS__          21
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MM0016GPL020__)
+#if defined(__32MM0016GPL020__)
     #define _CPU_NAME_                    "32MM0016GPL020"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -184,8 +196,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0016GPL028__)
+#if defined(__32MM0016GPL028__)
     #define _CPU_NAME_                    "32MM0016GPL028"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -196,8 +209,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0016GPL036__)
+#if defined(__32MM0016GPL036__)
     #define _CPU_NAME_                    "32MM0016GPL036"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -208,8 +222,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0032GPL020__)
+#if defined(__32MM0032GPL020__)
     #define _CPU_NAME_                    "32MM0032GPL020"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -220,8 +235,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0032GPL028__)
+#if defined(__32MM0032GPL028__)
     #define _CPU_NAME_                    "32MM0032GPL028"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -232,8 +248,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0032GPL036__)
+#if defined(__32MM0032GPL036__)
     #define _CPU_NAME_                    "32MM0032GPL036"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -244,8 +261,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0064GPL020__)
+#if defined(__32MM0064GPL020__)
     #define _CPU_NAME_                    "32MM0064GPL020"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -256,8 +274,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0064GPL028__)
+#if defined(__32MM0064GPL028__)
     #define _CPU_NAME_                    "32MM0064GPL028"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -268,8 +287,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0064GPL036__)
+#if defined(__32MM0064GPL036__)
     #define _CPU_NAME_                    "32MM0064GPL036"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -280,8 +300,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0064GPM028__)
+#if defined(__32MM0064GPM028__)
     #define _CPU_NAME_                    "32MM0064GPM028"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -294,8 +315,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0064GPM036__)
+#if defined(__32MM0064GPM036__)
     #define _CPU_NAME_                    "32MM0064GPM036"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -308,8 +330,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0064GPM048__)
+#if defined(__32MM0064GPM048__)
     #define _CPU_NAME_                    "32MM0064GPM048"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -322,8 +345,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0064GPM064__)
+#if defined(__32MM0064GPM064__)
     #define _CPU_NAME_                    "32MM0064GPM064"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -336,8 +360,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0128GPM028__)
+#if defined(__32MM0128GPM028__)
     #define _CPU_NAME_                    "32MM0128GPM028"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -350,8 +375,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0128GPM036__)
+#if defined(__32MM0128GPM036__)
     #define _CPU_NAME_                    "32MM0128GPM036"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -364,8 +390,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0128GPM048__)
+#if defined(__32MM0128GPM048__)
     #define _CPU_NAME_                    "32MM0128GPM048"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -378,8 +405,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0128GPM064__)
+#if defined(__32MM0128GPM064__)
     #define _CPU_NAME_                    "32MM0128GPM064"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -392,8 +420,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0256GPM028__)
+#if defined(__32MM0256GPM028__)
     #define _CPU_NAME_                    "32MM0256GPM028"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -406,8 +435,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0256GPM036__)
+#if defined(__32MM0256GPM036__)
     #define _CPU_NAME_                    "32MM0256GPM036"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -420,8 +450,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0256GPM048__)
+#if defined(__32MM0256GPM048__)
     #define _CPU_NAME_                    "32MM0256GPM048"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -434,8 +465,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MM0256GPM064__)
+#if defined(__32MM0256GPM064__)
     #define _CPU_NAME_                    "32MM0256GPM064"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -448,8 +480,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 256
     #define __FLASH_PAGE__                2048
+#endif
 
-#elif defined(__32MX110F016B__)
+#if defined(__32MX110F016B__)
     #define _CPU_NAME_                    "32MX110F016B"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -462,8 +495,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX110F016C__)
+#if defined(__32MX110F016C__)
     #define _CPU_NAME_                    "32MX110F016C"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -476,8 +510,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX110F016D__)
+#if defined(__32MX110F016D__)
     #define _CPU_NAME_                    "32MX110F016D"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -490,8 +525,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX120F032B__)
+#if defined(__32MX120F032B__)
     #define _CPU_NAME_                    "32MX120F032B"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -504,8 +540,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX120F032C__)
+#if defined(__32MX120F032C__)
     #define _CPU_NAME_                    "32MX120F032C"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -518,8 +555,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX120F032D__)
+#if defined(__32MX120F032D__)
     #define _CPU_NAME_                    "32MX120F032D"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -532,8 +570,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX120F064H__)
+#if defined(__32MX120F064H__)
     #define _CPU_NAME_                    "32MX120F064H"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -546,8 +585,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX130F064B__)
+#if defined(__32MX130F064B__)
     #define _CPU_NAME_                    "32MX130F064B"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -560,8 +600,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX130F064C__)
+#if defined(__32MX130F064C__)
     #define _CPU_NAME_                    "32MX130F064C"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -574,8 +615,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX130F064D__)
+#if defined(__32MX130F064D__)
     #define _CPU_NAME_                    "32MX130F064D"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -588,8 +630,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX130F128H__)
+#if defined(__32MX130F128H__)
     #define _CPU_NAME_                    "32MX130F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -602,8 +645,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX130F128L__)
+#if defined(__32MX130F128L__)
     #define _CPU_NAME_                    "32MX130F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -616,8 +660,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX130F256B__)
+#if defined(__32MX130F256B__)
     #define _CPU_NAME_                    "32MX130F256B"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -630,8 +675,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX130F256D__)
+#if defined(__32MX130F256D__)
     #define _CPU_NAME_                    "32MX130F256D"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -644,8 +690,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX150F128B__)
+#if defined(__32MX150F128B__)
     #define _CPU_NAME_                    "32MX150F128B"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -658,8 +705,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX150F128C__)
+#if defined(__32MX150F128C__)
     #define _CPU_NAME_                    "32MX150F128C"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -672,8 +720,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX150F128D__)
+#if defined(__32MX150F128D__)
     #define _CPU_NAME_                    "32MX150F128D"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -686,8 +735,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX150F256H__)
+#if defined(__32MX150F256H__)
     #define _CPU_NAME_                    "32MX150F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -700,8 +750,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX150F256L__)
+#if defined(__32MX150F256L__)
     #define _CPU_NAME_                    "32MX150F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -714,8 +765,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX154F128B__)
+#if defined(__32MX154F128B__)
     #define _CPU_NAME_                    "32MX154F128B"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -728,8 +780,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX154F128D__)
+#if defined(__32MX154F128D__)
     #define _CPU_NAME_                    "32MX154F128D"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -742,8 +795,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX170F256B__)
+#if defined(__32MX170F256B__)
     #define _CPU_NAME_                    "32MX170F256B"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -756,8 +810,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX170F256D__)
+#if defined(__32MX170F256D__)
     #define _CPU_NAME_                    "32MX170F256D"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -770,8 +825,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX170F512H__)
+#if defined(__32MX170F512H__)
     #define _CPU_NAME_                    "32MX170F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -785,8 +841,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX170F512L__)
+#if defined(__32MX170F512L__)
     #define _CPU_NAME_                    "32MX170F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -800,8 +857,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX174F256B__)
+#if defined(__32MX174F256B__)
     #define _CPU_NAME_                    "32MX174F256B"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -814,8 +872,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX174F256D__)
+#if defined(__32MX174F256D__)
     #define _CPU_NAME_                    "32MX174F256D"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -828,8 +887,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX210F016B__)
+#if defined(__32MX210F016B__)
     #define _CPU_NAME_                    "32MX210F016B"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -842,8 +902,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX210F016C__)
+#if defined(__32MX210F016C__)
     #define _CPU_NAME_                    "32MX210F016C"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -856,8 +917,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX210F016D__)
+#if defined(__32MX210F016D__)
     #define _CPU_NAME_                    "32MX210F016D"
     #define FLASHEND                      (((16 - 4) * 1024L) - 1)
     #define RAMEND                        ((4 * 1024L) - 1)
@@ -870,8 +932,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX220F032B__)
+#if defined(__32MX220F032B__)
     #define _CPU_NAME_                    "32MX220F032B"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -884,8 +947,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX220F032C__)
+#if defined(__32MX220F032C__)
     #define _CPU_NAME_                    "32MX220F032C"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -898,8 +962,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX220F032D__)
+#if defined(__32MX220F032D__)
     #define _CPU_NAME_                    "32MX220F032D"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -912,8 +977,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX230F064B__)
+#if defined(__32MX230F064B__)
     #define _CPU_NAME_                    "32MX230F064B"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -926,8 +992,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX230F064C__)
+#if defined(__32MX230F064C__)
     #define _CPU_NAME_                    "32MX230F064C"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -940,8 +1007,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX230F064D__)
+#if defined(__32MX230F064D__)
     #define _CPU_NAME_                    "32MX230F064D"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -954,8 +1022,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX230F128H__)
+#if defined(__32MX230F128H__)
     #define _CPU_NAME_                    "32MX230F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -968,8 +1037,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX230F128L__)
+#if defined(__32MX230F128L__)
     #define _CPU_NAME_                    "32MX230F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -982,8 +1052,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX230F256B__)
+#if defined(__32MX230F256B__)
     #define _CPU_NAME_                    "32MX230F256B"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -996,8 +1067,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX230F256D__)
+#if defined(__32MX230F256D__)
     #define _CPU_NAME_                    "32MX230F256D"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1010,8 +1082,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX250F128B__)
+#if defined(__32MX250F128B__)
     #define _CPU_NAME_                    "32MX250F128B"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1024,8 +1097,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX250F128C__)
+#if defined(__32MX250F128C__)
     #define _CPU_NAME_                    "32MX250F128C"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1038,8 +1112,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX250F128D__)
+#if defined(__32MX250F128D__)
     #define _CPU_NAME_                    "32MX250F128D"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1052,8 +1127,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX250F256H__)
+#if defined(__32MX250F256H__)
     #define _CPU_NAME_                    "32MX250F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1066,8 +1142,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX250F256L__)
+#if defined(__32MX250F256L__)
     #define _CPU_NAME_                    "32MX250F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1080,8 +1157,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX254F128B__)
+#if defined(__32MX254F128B__)
     #define _CPU_NAME_                    "32MX254F128B"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1094,8 +1172,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX254F128D__)
+#if defined(__32MX254F128D__)
     #define _CPU_NAME_                    "32MX254F128D"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1106,8 +1185,9 @@
     #define __NUM_USB_MODULES__           1
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX270F256B__)
+#if defined(__32MX270F256B__)
     #define _CPU_NAME_                    "32MX270F256B"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1120,8 +1200,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX270F256D__)
+#if defined(__32MX270F256D__)
     #define _CPU_NAME_                    "32MX270F256D"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1134,8 +1215,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX270F512H__)
+#if defined(__32MX270F512H__)
     #define _CPU_NAME_                    "32MX270F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1149,8 +1231,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX270F512L__)
+#if defined(__32MX270F512L__)
     #define _CPU_NAME_                    "32MX270F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1164,8 +1247,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX274F256B__)
+#if defined(__32MX274F256B__)
     #define _CPU_NAME_                    "32MX274F256B"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1178,8 +1262,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX274F256D__)
+#if defined(__32MX274F256D__)
     #define _CPU_NAME_                    "32MX274F256D"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1192,8 +1277,9 @@
     #define __NUM_DMA_CHANNELS__          6
     #define __FLASH_ROW__                 128
     #define __FLASH_PAGE__                1024
+#endif
 
-#elif defined(__32MX320F032H__)
+#if defined(__32MX320F032H__)
     #define _CPU_NAME_                    "32MX320F032H"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -1203,8 +1289,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX320F064H__)
+#if defined(__32MX320F064H__)
     #define _CPU_NAME_                    "32MX320F064H"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1214,8 +1301,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX320F128H__)
+#if defined(__32MX320F128H__)
     #define _CPU_NAME_                    "32MX320F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1225,8 +1313,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX320F128L__)
+#if defined(__32MX320F128L__)
     #define _CPU_NAME_                    "32MX320F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1236,8 +1325,9 @@
     #define __NUM_USB_MODULES__           0
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX330F064H__)
+#if defined(__32MX330F064H__)
     #define _CPU_NAME_                    "32MX330F064H"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1250,8 +1340,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX330F064L__)
+#if defined(__32MX330F064L__)
     #define _CPU_NAME_                    "32MX330F064L"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1264,8 +1355,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX340F128H__)
+#if defined(__32MX340F128H__)
     #define _CPU_NAME_                    "32MX340F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1277,8 +1369,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX340F128L__)
+#if defined(__32MX340F128L__)
     #define _CPU_NAME_                    "32MX340F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1290,8 +1383,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX340F256H__)
+#if defined(__32MX340F256H__)
     #define _CPU_NAME_                    "32MX340F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1303,8 +1397,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX340F512H__)
+#if defined(__32MX340F512H__)
     #define _CPU_NAME_                    "32MX340F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1316,8 +1411,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX350F128H__)
+#if defined(__32MX350F128H__)
     #define _CPU_NAME_                    "32MX350F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1330,8 +1426,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX350F128L__)
+#if defined(__32MX350F128L__)
     #define _CPU_NAME_                    "32MX350F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1344,8 +1441,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX350F256H__)
+#if defined(__32MX350F256H__)
     #define _CPU_NAME_                    "32MX350F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1358,8 +1456,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX350F256L__)
+#if defined(__32MX350F256L__)
     #define _CPU_NAME_                    "32MX350F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1372,8 +1471,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX360F256L__)
+#if defined(__32MX360F256L__)
     #define _CPU_NAME_                    "32MX360F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1385,8 +1485,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX360F512L__)
+#if defined(__32MX360F512L__)
     #define _CPU_NAME_                    "32MX360F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1398,8 +1499,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX370F512H__)
+#if defined(__32MX370F512H__)
     #define _CPU_NAME_                    "32MX370F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1413,8 +1515,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX370F512L__)
+#if defined(__32MX370F512L__)
     #define _CPU_NAME_                    "32MX370F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1428,8 +1531,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX420F032H__)
+#if defined(__32MX420F032H__)
     #define _CPU_NAME_                    "32MX420F032H"
     #define FLASHEND                      (((32 - 4) * 1024L) - 1)
     #define RAMEND                        ((8 * 1024L) - 1)
@@ -1439,8 +1543,9 @@
     #define __NUM_USB_MODULES__           1
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX430F064H__)
+#if defined(__32MX430F064H__)
     #define _CPU_NAME_                    "32MX430F064H"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1453,8 +1558,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX430F064L__)
+#if defined(__32MX430F064L__)
     #define _CPU_NAME_                    "32MX430F064L"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1467,8 +1573,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX440F128H__)
+#if defined(__32MX440F128H__)
     #define _CPU_NAME_                    "32MX440F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1480,8 +1587,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX440F128L__)
+#if defined(__32MX440F128L__)
     #define _CPU_NAME_                    "32MX440F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1493,8 +1601,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX440F256H__)
+#if defined(__32MX440F256H__)
     #define _CPU_NAME_                    "32MX440F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1506,8 +1615,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX440F512H__)
+#if defined(__32MX440F512H__)
     #define _CPU_NAME_                    "32MX440F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1519,8 +1629,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX450F128H__)
+#if defined(__32MX450F128H__)
     #define _CPU_NAME_                    "32MX450F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1533,8 +1644,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX450F128L__)
+#if defined(__32MX450F128L__)
     #define _CPU_NAME_                    "32MX450F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1547,8 +1659,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX450F256H__)
+#if defined(__32MX450F256H__)
     #define _CPU_NAME_                    "32MX450F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1561,8 +1674,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX450F256L__)
+#if defined(__32MX450F256L__)
     #define _CPU_NAME_                    "32MX450F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1575,8 +1689,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX460F256L__)
+#if defined(__32MX460F256L__)
     #define _CPU_NAME_                    "32MX460F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1588,8 +1703,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX460F512L__)
+#if defined(__32MX460F512L__)
     #define _CPU_NAME_                    "32MX460F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1601,8 +1717,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX470F512H__)
+#if defined(__32MX470F512H__)
     #define _CPU_NAME_                    "32MX470F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1616,8 +1733,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX470F512L__)
+#if defined(__32MX470F512L__)
     #define _CPU_NAME_                    "32MX470F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1631,8 +1749,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX530F128H__)
+#if defined(__32MX530F128H__)
     #define _CPU_NAME_                    "32MX530F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1645,8 +1764,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX530F128L__)
+#if defined(__32MX530F128L__)
     #define _CPU_NAME_                    "32MX530F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1659,8 +1779,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX534F064H__)
+#if defined(__32MX534F064H__)
     #define _CPU_NAME_                    "32MX534F064H"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1672,8 +1793,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX534F064L__)
+#if defined(__32MX534F064L__)
     #define _CPU_NAME_                    "32MX534F064L"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1685,8 +1807,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX550F256H__)
+#if defined(__32MX550F256H__)
     #define _CPU_NAME_                    "32MX550F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1699,8 +1822,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX550F256L__)
+#if defined(__32MX550F256L__)
     #define _CPU_NAME_                    "32MX550F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1713,8 +1837,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX564F064H__)
+#if defined(__32MX564F064H__)
     #define _CPU_NAME_                    "32MX564F064H"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1726,8 +1851,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX564F064L__)
+#if defined(__32MX564F064L__)
     #define _CPU_NAME_                    "32MX564F064L"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1739,8 +1865,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX564F128H__)
+#if defined(__32MX564F128H__)
     #define _CPU_NAME_                    "32MX564F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1752,8 +1879,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX564F128L__)
+#if defined(__32MX564F128L__)
     #define _CPU_NAME_                    "32MX564F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1765,8 +1893,9 @@
     #define __NUM_DMA_CHANNELS__          4
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX570F512H__)
+#if defined(__32MX570F512H__)
     #define _CPU_NAME_                    "32MX570F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1780,8 +1909,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX570F512L__)
+#if defined(__32MX570F512L__)
     #define _CPU_NAME_                    "32MX570F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1795,8 +1925,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX575F256H__)
+#if defined(__32MX575F256H__)
     #define _CPU_NAME_                    "32MX575F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1808,8 +1939,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX575F256L__)
+#if defined(__32MX575F256L__)
     #define _CPU_NAME_                    "32MX575F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1821,8 +1953,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX575F512H__)
+#if defined(__32MX575F512H__)
     #define _CPU_NAME_                    "32MX575F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1834,8 +1967,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX575F512L__)
+#if defined(__32MX575F512L__)
     #define _CPU_NAME_                    "32MX575F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1848,8 +1982,9 @@
     #define __NUM_DMA_CHANNELS__          8
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX664F064H__)
+#if defined(__32MX664F064H__)
     #define _CPU_NAME_                    "32MX664F064H"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1862,8 +1997,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX664F064L__)
+#if defined(__32MX664F064L__)
     #define _CPU_NAME_                    "32MX664F064L"
     #define FLASHEND                      (((64 - 4) * 1024L) - 1)
     #define RAMEND                        ((16 * 1024L) - 1)
@@ -1876,8 +2012,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX664F128H__)
+#if defined(__32MX664F128H__)
     #define _CPU_NAME_                    "32MX664F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1890,8 +2027,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX664F128L__)
+#if defined(__32MX664F128L__)
     #define _CPU_NAME_                    "32MX664F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -1904,8 +2042,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX675F256H__)
+#if defined(__32MX675F256H__)
     #define _CPU_NAME_                    "32MX675F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1918,8 +2057,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX675F256L__)
+#if defined(__32MX675F256L__)
     #define _CPU_NAME_                    "32MX675F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -1932,8 +2072,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX675F512H__)
+#if defined(__32MX675F512H__)
     #define _CPU_NAME_                    "32MX675F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1946,8 +2087,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX675F512L__)
+#if defined(__32MX675F512L__)
     #define _CPU_NAME_                    "32MX675F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1960,8 +2102,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX695F512H__)
+#if defined(__32MX695F512H__)
     #define _CPU_NAME_                    "32MX695F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1974,8 +2117,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX695F512L__)
+#if defined(__32MX695F512L__)
     #define _CPU_NAME_                    "32MX695F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -1988,8 +2132,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX764F128H__)
+#if defined(__32MX764F128H__)
     #define _CPU_NAME_                    "32MX764F128H"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -2002,8 +2147,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX764F128L__)
+#if defined(__32MX764F128L__)
     #define _CPU_NAME_                    "32MX764F128L"
     #define FLASHEND                      (((128 - 4) * 1024L) - 1)
     #define RAMEND                        ((32 * 1024L) - 1)
@@ -2016,8 +2162,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX775F256H__)
+#if defined(__32MX775F256H__)
     #define _CPU_NAME_                    "32MX775F256H"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -2030,8 +2177,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX775F256L__)
+#if defined(__32MX775F256L__)
     #define _CPU_NAME_                    "32MX775F256L"
     #define FLASHEND                      (((256 - 4) * 1024L) - 1)
     #define RAMEND                        ((64 * 1024L) - 1)
@@ -2044,8 +2192,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX775F512H__)
+#if defined(__32MX775F512H__)
     #define _CPU_NAME_                    "32MX775F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2058,8 +2207,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX775F512L__)
+#if defined(__32MX775F512L__)
     #define _CPU_NAME_                    "32MX775F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2072,8 +2222,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX795F512H__)
+#if defined(__32MX795F512H__)
     #define _CPU_NAME_                    "32MX795F512H"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2086,8 +2237,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MX795F512L__)
+#if defined(__32MX795F512L__)
     #define _CPU_NAME_                    "32MX795F512L"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2100,8 +2252,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFE064__)
+#if defined(__32MZ0512EFE064__)
     #define _CPU_NAME_                    "32MZ0512EFE064"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2116,8 +2269,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFE100__)
+#if defined(__32MZ0512EFE100__)
     #define _CPU_NAME_                    "32MZ0512EFE100"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2132,8 +2286,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFE124__)
+#if defined(__32MZ0512EFE124__)
     #define _CPU_NAME_                    "32MZ0512EFE124"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2148,8 +2303,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFE144__)
+#if defined(__32MZ0512EFE144__)
     #define _CPU_NAME_                    "32MZ0512EFE144"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2164,8 +2320,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFF064__)
+#if defined(__32MZ0512EFF064__)
     #define _CPU_NAME_                    "32MZ0512EFF064"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2180,8 +2337,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFF100__)
+#if defined(__32MZ0512EFF100__)
     #define _CPU_NAME_                    "32MZ0512EFF100"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2196,8 +2354,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFF124__)
+#if defined(__32MZ0512EFF124__)
     #define _CPU_NAME_                    "32MZ0512EFF124"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2212,8 +2371,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFF144__)
+#if defined(__32MZ0512EFF144__)
     #define _CPU_NAME_                    "32MZ0512EFF144"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2228,8 +2388,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFK064__)
+#if defined(__32MZ0512EFK064__)
     #define _CPU_NAME_                    "32MZ0512EFK064"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2245,8 +2406,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFK100__)
+#if defined(__32MZ0512EFK100__)
     #define _CPU_NAME_                    "32MZ0512EFK100"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2262,8 +2424,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFK124__)
+#if defined(__32MZ0512EFK124__)
     #define _CPU_NAME_                    "32MZ0512EFK124"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2279,8 +2442,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ0512EFK144__)
+#if defined(__32MZ0512EFK144__)
     #define _CPU_NAME_                    "32MZ0512EFK144"
     #define FLASHEND                      (((512 - 4) * 1024L) - 1)
     #define RAMEND                        ((128 * 1024L) - 1)
@@ -2296,8 +2460,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFE064__)
+#if defined(__32MZ1024EFE064__)
     #define _CPU_NAME_                    "32MZ1024EFE064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2312,8 +2477,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFE100__)
+#if defined(__32MZ1024EFE100__)
     #define _CPU_NAME_                    "32MZ1024EFE100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2328,8 +2494,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFE124__)
+#if defined(__32MZ1024EFE124__)
     #define _CPU_NAME_                    "32MZ1024EFE124"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2344,8 +2511,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFE144__)
+#if defined(__32MZ1024EFE144__)
     #define _CPU_NAME_                    "32MZ1024EFE144"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2360,8 +2528,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFF064__)
+#if defined(__32MZ1024EFF064__)
     #define _CPU_NAME_                    "32MZ1024EFF064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2376,8 +2545,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFF100__)
+#if defined(__32MZ1024EFF100__)
     #define _CPU_NAME_                    "32MZ1024EFF100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2392,8 +2562,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFF124__)
+#if defined(__32MZ1024EFF124__)
     #define _CPU_NAME_                    "32MZ1024EFF124"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2408,8 +2579,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFF144__)
+#if defined(__32MZ1024EFF144__)
     #define _CPU_NAME_                    "32MZ1024EFF144"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2424,8 +2596,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFG064__)
+#if defined(__32MZ1024EFG064__)
     #define _CPU_NAME_                    "32MZ1024EFG064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2440,8 +2613,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFG100__)
+#if defined(__32MZ1024EFG100__)
     #define _CPU_NAME_                    "32MZ1024EFG100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2456,8 +2630,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFG124__)
+#if defined(__32MZ1024EFG124__)
     #define _CPU_NAME_                    "32MZ1024EFG124"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2472,8 +2647,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFG144__)
+#if defined(__32MZ1024EFG144__)
     #define _CPU_NAME_                    "32MZ1024EFG144"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2488,8 +2664,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFH064__)
+#if defined(__32MZ1024EFH064__)
     #define _CPU_NAME_                    "32MZ1024EFH064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2504,8 +2681,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFH100__)
+#if defined(__32MZ1024EFH100__)
     #define _CPU_NAME_                    "32MZ1024EFH100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2520,8 +2698,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFH124__)
+#if defined(__32MZ1024EFH124__)
     #define _CPU_NAME_                    "32MZ1024EFH124"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2536,8 +2715,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFH144__)
+#if defined(__32MZ1024EFH144__)
     #define _CPU_NAME_                    "32MZ1024EFH144"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2552,8 +2732,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFK064__)
+#if defined(__32MZ1024EFK064__)
     #define _CPU_NAME_                    "32MZ1024EFK064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2569,8 +2750,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFK100__)
+#if defined(__32MZ1024EFK100__)
     #define _CPU_NAME_                    "32MZ1024EFK100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2586,8 +2768,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFK124__)
+#if defined(__32MZ1024EFK124__)
     #define _CPU_NAME_                    "32MZ1024EFK124"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2603,8 +2786,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFK144__)
+#if defined(__32MZ1024EFK144__)
     #define _CPU_NAME_                    "32MZ1024EFK144"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2620,8 +2804,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFM064__)
+#if defined(__32MZ1024EFM064__)
     #define _CPU_NAME_                    "32MZ1024EFM064"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2637,8 +2822,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFM100__)
+#if defined(__32MZ1024EFM100__)
     #define _CPU_NAME_                    "32MZ1024EFM100"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2654,8 +2840,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFM124__)
+#if defined(__32MZ1024EFM124__)
     #define _CPU_NAME_                    "32MZ1024EFM124"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2671,8 +2858,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1024EFM144__)
+#if defined(__32MZ1024EFM144__)
     #define _CPU_NAME_                    "32MZ1024EFM144"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -2688,8 +2876,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAA169__)
+#if defined(__32MZ1025DAA169__)
     #define _CPU_NAME_                    "32MZ1025DAA169"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2704,8 +2893,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAA176__)
+#if defined(__32MZ1025DAA176__)
     #define _CPU_NAME_                    "32MZ1025DAA176"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2720,8 +2910,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAA288__)
+#if defined(__32MZ1025DAA288__)
     #define _CPU_NAME_                    "32MZ1025DAA288"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2737,8 +2928,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAB169__)
+#if defined(__32MZ1025DAB169__)
     #define _CPU_NAME_                    "32MZ1025DAB169"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2754,8 +2946,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAB176__)
+#if defined(__32MZ1025DAB176__)
     #define _CPU_NAME_                    "32MZ1025DAB176"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2771,8 +2964,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAB288__)
+#if defined(__32MZ1025DAB288__)
     #define _CPU_NAME_                    "32MZ1025DAB288"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2789,8 +2983,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAG169__)
+#if defined(__32MZ1025DAG169__)
     #define _CPU_NAME_                    "32MZ1025DAG169"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2807,8 +3002,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAG176__)
+#if defined(__32MZ1025DAG176__)
     #define _CPU_NAME_                    "32MZ1025DAG176"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2825,8 +3021,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAH169__)
+#if defined(__32MZ1025DAH169__)
     #define _CPU_NAME_                    "32MZ1025DAH169"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2844,8 +3041,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1025DAH176__)
+#if defined(__32MZ1025DAH176__)
     #define _CPU_NAME_                    "32MZ1025DAH176"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -2863,8 +3061,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAA169__)
+#if defined(__32MZ1064DAA169__)
     #define _CPU_NAME_                    "32MZ1064DAA169"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -2879,8 +3078,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAA176__)
+#if defined(__32MZ1064DAA176__)
     #define _CPU_NAME_                    "32MZ1064DAA176"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -2895,8 +3095,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAA288__)
+#if defined(__32MZ1064DAA288__)
     #define _CPU_NAME_                    "32MZ1064DAA288"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -2912,8 +3113,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAB169__)
+#if defined(__32MZ1064DAB169__)
     #define _CPU_NAME_                    "32MZ1064DAB169"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -2929,8 +3131,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAB176__)
+#if defined(__32MZ1064DAB176__)
     #define _CPU_NAME_                    "32MZ1064DAB176"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -2946,8 +3149,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAB288__)
+#if defined(__32MZ1064DAB288__)
     #define _CPU_NAME_                    "32MZ1064DAB288"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -2964,8 +3168,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAG169__)
+#if defined(__32MZ1064DAG169__)
     #define _CPU_NAME_                    "32MZ1064DAG169"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -2982,8 +3187,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAG176__)
+#if defined(__32MZ1064DAG176__)
     #define _CPU_NAME_                    "32MZ1064DAG176"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3000,8 +3206,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAH169__)
+#if defined(__32MZ1064DAH169__)
     #define _CPU_NAME_                    "32MZ1064DAH169"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3019,8 +3226,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ1064DAH176__)
+#if defined(__32MZ1064DAH176__)
     #define _CPU_NAME_                    "32MZ1064DAH176"
     #define FLASHEND                      (((1024 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3038,8 +3246,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAA169__)
+#if defined(__32MZ2025DAA169__)
     #define _CPU_NAME_                    "32MZ2025DAA169"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3054,8 +3263,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAA176__)
+#if defined(__32MZ2025DAA176__)
     #define _CPU_NAME_                    "32MZ2025DAA176"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3069,8 +3279,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAA288__)
+#if defined(__32MZ2025DAA288__)
     #define _CPU_NAME_                    "32MZ2025DAA288"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3086,8 +3297,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAB169__)
+#if defined(__32MZ2025DAB169__)
     #define _CPU_NAME_                    "32MZ2025DAB169"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3103,8 +3315,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAB176__)
+#if defined(__32MZ2025DAB176__)
     #define _CPU_NAME_                    "32MZ2025DAB176"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3120,8 +3333,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAB288__)
+#if defined(__32MZ2025DAB288__)
     #define _CPU_NAME_                    "32MZ2025DAB288"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3138,8 +3352,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAG169__)
+#if defined(__32MZ2025DAG169__)
     #define _CPU_NAME_                    "32MZ2025DAG169"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3156,8 +3371,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAG176__)
+#if defined(__32MZ2025DAG176__)
     #define _CPU_NAME_                    "32MZ2025DAG176"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3174,8 +3390,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAH169__)
+#if defined(__32MZ2025DAH169__)
     #define _CPU_NAME_                    "32MZ2025DAH169"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3193,8 +3410,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2025DAH176__)
+#if defined(__32MZ2025DAH176__)
     #define _CPU_NAME_                    "32MZ2025DAH176"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((256 * 1024L) - 1)
@@ -3212,8 +3430,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFG064__)
+#if defined(__32MZ2048EFG064__)
     #define _CPU_NAME_                    "32MZ2048EFG064"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3228,8 +3447,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFG100__)
+#if defined(__32MZ2048EFG100__)
     #define _CPU_NAME_                    "32MZ2048EFG100"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3244,8 +3464,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFG124__)
+#if defined(__32MZ2048EFG124__)
     #define _CPU_NAME_                    "32MZ2048EFG124"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3260,8 +3481,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFG144__)
+#if defined(__32MZ2048EFG144__)
     #define _CPU_NAME_                    "32MZ2048EFG144"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3276,8 +3498,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFH064__)
+#if defined(__32MZ2048EFH064__)
     #define _CPU_NAME_                    "32MZ2048EFH064"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3292,8 +3515,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFH100__)
+#if defined(__32MZ2048EFH100__)
     #define _CPU_NAME_                    "32MZ2048EFH100"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3308,8 +3532,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFH124__)
+#if defined(__32MZ2048EFH124__)
     #define _CPU_NAME_                    "32MZ2048EFH124"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3324,8 +3549,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFH144__)
+#if defined(__32MZ2048EFH144__)
     #define _CPU_NAME_                    "32MZ2048EFH144"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3340,8 +3566,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFM064__)
+#if defined(__32MZ2048EFM064__)
     #define _CPU_NAME_                    "32MZ2048EFM064"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3357,8 +3584,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFM100__)
+#if defined(__32MZ2048EFM100__)
     #define _CPU_NAME_                    "32MZ2048EFM100"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3374,8 +3602,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFM124__)
+#if defined(__32MZ2048EFM124__)
     #define _CPU_NAME_                    "32MZ2048EFM124"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3391,8 +3620,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2048EFM144__)
+#if defined(__32MZ2048EFM144__)
     #define _CPU_NAME_                    "32MZ2048EFM144"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((512 * 1024L) - 1)
@@ -3408,8 +3638,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAA169__)
+#if defined(__32MZ2064DAA169__)
     #define _CPU_NAME_                    "32MZ2064DAA169"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3424,8 +3655,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAA176__)
+#if defined(__32MZ2064DAA176__)
     #define _CPU_NAME_                    "32MZ2064DAA176"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3440,8 +3672,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAA288__)
+#if defined(__32MZ2064DAA288__)
     #define _CPU_NAME_                    "32MZ2064DAA288"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3457,8 +3690,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAB169__)
+#if defined(__32MZ2064DAB169__)
     #define _CPU_NAME_                    "32MZ2064DAB169"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3474,8 +3708,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAB176__)
+#if defined(__32MZ2064DAB176__)
     #define _CPU_NAME_                    "32MZ2064DAB176"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3491,8 +3726,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAB288__)
+#if defined(__32MZ2064DAB288__)
     #define _CPU_NAME_                    "32MZ2064DAB288"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3509,8 +3745,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAG169__)
+#if defined(__32MZ2064DAG169__)
     #define _CPU_NAME_                    "32MZ2064DAG169"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3527,8 +3764,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAG176__)
+#if defined(__32MZ2064DAG176__)
     #define _CPU_NAME_                    "32MZ2064DAG176"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3545,8 +3783,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAH169__)
+#if defined(__32MZ2064DAH169__)
     #define _CPU_NAME_                    "32MZ2064DAH169"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3564,8 +3803,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#elif defined(__32MZ2064DAH176__)
+#if defined(__32MZ2064DAH176__)
     #define _CPU_NAME_                    "32MZ2064DAH176"
     #define FLASHEND                      (((2048 - 4) * 1024L) - 1)
     #define RAMEND                        ((640 * 1024L) - 1)
@@ -3583,7 +3823,9 @@
     #define __HAS_ETHERNET__
     #define __FLASH_ROW__                 512
     #define __FLASH_PAGE__                4096
+#endif
 
-#else
+#include "cpudefs_retired.h"
+#ifndef _CPU_NAME_
     #error CPU type is unknown, cpudefs.h needs to have additions
 #endif

--- a/pic32/cores/pic32/makechips.pl
+++ b/pic32/cores/pic32/makechips.pl
@@ -39,19 +39,12 @@ while (my $line = <CSV>) {
 close (CSV);
 
 
-my $first = 1;
-
 foreach my $chip (sort keys %{$chipdata}) {
     if ($chipdata->{$chip}->{'CPU Type'} == '32-bit MIPS MCU') {
 
         my $cname = $chip;
         $cname =~ s/^PIC//g;
-        if ($first == 1) {
-            print "#if defined(__" . $cname . "__)\n";
-            $first = 0;
-        } else {
-            print "#elif defined(__" . $cname . "__)\n";
-        }
+        print "#if defined(__" . $cname . "__)\n";
 
         my $ram = $chipdata->{$chip}->{'RAM (KB)'};
         my $ddr = 0;
@@ -116,11 +109,13 @@ foreach my $chip (sort keys %{$chipdata}) {
         print "    #define __FLASH_PAGE__                " . flashPage($fam) . "\n";
 
 
-        print "\n";
+        print "#endif\n\n";
     }
 }
 
-print "#else\n";
+print "#include \"cpudefs_retired.h\"\n";
+
+print "#ifndef _CPU_NAME_\n";
 print "    #error CPU type is unknown, cpudefs.h needs to have additions\n";
 
 print "#endif\n";


### PR DESCRIPTION
Microchip, in their wisdom, no longer list the MZ EC chips in their catalog. It's like they're trying to deny they ever existed (and who can blame them...?). As a result they never got added into the generated cpudefs_table.h file by the generating script.

This PR adds those missing chips by placing them in a "retired" cpudefs file where future retired chips can be moved to when Microchip drop them from their catalog.

Also adjusted how the chips definitions are included so that it's easier to make multiple chunks like this.