### PR TITLE
Wire.write() to support passing uint32_t (and by promotion uint_16_t).

### DIFF
--- a/pic32/libraries/Wire/Wire.cpp
+++ b/pic32/libraries/Wire/Wire.cpp
@@ -284,6 +284,7 @@ int TwoWire::write(uint8_t data)
 {
     return(di2c.write((const byte *) &data, 1));
 }
+int TwoWire::write(uint32_t data){ return(write((uint8_t) data)); }
 void TwoWire::send(uint8_t data) { write(data); }
 
 // must be called in:

--- a/pic32/libraries/Wire/Wire.h
+++ b/pic32/libraries/Wire/Wire.h
@@ -105,6 +105,7 @@ class TwoWire
     void __attribute__((deprecated("Use write() instead"))) send(int);
     void __attribute__((deprecated("Use write() instead"))) send(char*);
     int write(uint8_t);
+    int write(uint32_t);
     int write(uint8_t*, uint8_t);
     int write(int);
     int write(char*);


### PR DESCRIPTION
Compiles, not tested on hardware.  I think its going to work.