### PR TITLE
Restored File::readDir to SD library

### DIFF
--- a/pic32/libraries/SD/File.cpp
+++ b/pic32/libraries/SD/File.cpp
@@ -149,3 +149,9 @@ File::operator bool() {
   return false;
 }
 
+int8_t File::readDir(dir_t* dir) {
+    if (_file)
+        return _file->readDir(dir);
+    return false;
+}
+

--- a/pic32/libraries/SD/SD.h
+++ b/pic32/libraries/SD/SD.h
@@ -50,6 +50,7 @@ public:
   boolean isDirectory(void);
   File openNextFile(uint8_t mode = O_RDONLY);
   void rewindDirectory(void);
+  int8_t readDir(dir_t *dir);
   
   using Print::write;
 };


### PR DESCRIPTION
Not sure if this was ever actually in the core copy of the library or not, or if I just had it in an old custom UECIDE version, but readDir() is a pretty essential function if you want to examine the contents of a directory.

This exposes (or re-exposes) the internal readDir call through the File class.