### PR TITLE
Change constructor to take CS pin not pullup flag.

### DIFF
--- a/pic32/libraries/DSDVOL/DSDVOL.cpp
+++ b/pic32/libraries/DSDVOL/DSDVOL.cpp
@@ -24,11 +24,8 @@
 
 void DSDVOL::power_on (void)
 {
-    if(pinPullup1 != pinPullupNone)
-    {
-        pinMode(pinPullup1, INPUT_PULLUP);
-    }
-
+    pinMode(_csPin, OUTPUT);
+    digitalWrite(_csPin, HIGH);
     dSDspi.begin();
  
     dSDspi.setMode(DSPI_MODE0);
@@ -38,10 +35,7 @@ void DSDVOL::power_on (void)
 void DSDVOL::power_off (void)
 {
     dSDspi.end();
-    if(pinPullup1 != pinPullupNone)
-    {
-        pinMode(pinPullup1, INPUT);
-    }
+    pinMode(_csPin, INPUT);
 }
 
 /*-----------------------------------------------------------------------*/
@@ -65,6 +59,7 @@ int DSDVOL::wait_ready (void)
 		d = xchg_spi(0xFF);
 	} while ((d != 0xFF) && tmsTimer(2));
 
+
 	return (d == 0xFF) ? 1 : 0;
 }
 
@@ -74,8 +69,9 @@ int DSDVOL::wait_ready (void)
 
 void DSDVOL::deselect (void)
 {
-    dSDspi.setSelect(HIGH);
+    digitalWrite(_csPin, HIGH);
 	xchg_spi(0xFF);		/* Dummy clock (force DO hi-z for multiple slave SPI) */
+//    restoreInterrupts(_intStat);
 }
 
 /*-----------------------------------------------------------------------*/
@@ -84,7 +80,8 @@ void DSDVOL::deselect (void)
 
 int DSDVOL::select (void)	/* 1:Successful, 0:Timeout */
 {
-    dSDspi.setSelect(LOW);
+//    _intStat = disableInterrupts();
+    digitalWrite(_csPin, LOW);
 	xchg_spi(0xFF);			// Dummy clock (force DO enabled)
 
 	if (wait_ready()) {

--- a/pic32/libraries/DSDVOL/DSDVOL.h
+++ b/pic32/libraries/DSDVOL/DSDVOL.h
@@ -50,7 +50,7 @@
 #include "../DSPI/DSPI.h"           // required for the interface DGSPI
 #include "../SoftSPI/SoftSPI.h"     // required so SoftSPI does not have to be included 
                                     // if board_Defs uses a macro to define a SoftSPI
-#define sdSpiFast           4000000
+#define sdSpiFast           20000000
 #define sdSpiSlow           400000
 
 #define	FCLK_SLOW()		dSDspi.setSpeed(sdSpiSlow)	/* Set slow clock (100k-400k) */
@@ -98,7 +98,7 @@ class DSDVOL : public DFSVOL
         // variables used by the MMC/SD
         volatile DSTATUS    Stat;	
         uint32_t            CardType;
-	    uint8_t				pinPullup1;		// digital pin to turn on the internal pullups
+	    uint8_t				_csPin;
         tmsDefineTimer(1);
         tmsDefineTimer(2);
 
@@ -127,10 +127,14 @@ class DSDVOL : public DFSVOL
         int xmit_datablock (const uint8_t *buff, uint8_t token);
         uint8_t send_cmd (uint8_t cmd, uint32_t arg);
 
+        uint32_t _intStat;
+
     public:
 
-        DSDVOL(DGSPI& dspi, uint8_t pullup1) : DFSVOL(0,1), dSDspi(dspi), Stat(STA_NOINIT), pinPullup1(pullup1) {}
-        DSDVOL(DGSPI& dspi) : DSDVOL(dspi, pinPullupNone) {}
+        DSDVOL(DGSPI& dspi, uint8_t cs) : DFSVOL(0,1), dSDspi(dspi), Stat(STA_NOINIT), _csPin(cs) {}
+#ifdef PIN_SD_CS
+        DSDVOL(DGSPI& dspi) : DSDVOL(dspi, PIN_SD_CS) {}
+#endif
 
         DSTATUS disk_initialize (void);
         DSTATUS disk_status (void);


### PR DESCRIPTION
Also now uses the provided CS pin instead of only being able to work with the DSPI-provided default SS pin.  As per issue #430 