### PR TITLE
Fixed "pasting "/*JK*/" and "SET" does not give a valid preprocessing token" error

### DIFF
--- a/pic32/variants/Cerebot_MX4cK/Board_Defs.h
+++ b/pic32/variants/Cerebot_MX4cK/Board_Defs.h
@@ -399,7 +399,7 @@ extern const uint8_t	analog_pin_to_channel_PGM[];
 #define SD_CS_PIN 64
 
 //Pin 65
-#define	prtSDO				IOPORT_B	//JK
+#define	prtSDO				IOPORT_B
 #define	bnSDO				BIT_11
 
 //Pin 66


### PR DESCRIPTION
The error occurred during compiling, when SD library was being used. Other libraries that include this file might also have such issue.