### PR TITLE
Implement USB.resume() for remote wakeup of PC

### DIFF
--- a/pic32/cores/pic32/USB.cpp
+++ b/pic32/cores/pic32/USB.cpp
@@ -121,7 +121,7 @@ USBManager::USBManager(USBDriver *driver, uint16_t vid, uint16_t pid, const char
     _stringCount = 4;
     _manufacturer = mfg;
     _product = prod;
-    _deviceAttributes = 0x80; // Bus powered
+    _deviceAttributes = 0xA0; // Bus powered
     _devicePower = 250; // 500mA
     if (ser) {
         _serial = ser;

--- a/pic32/cores/pic32/USB.h
+++ b/pic32/cores/pic32/USB.h
@@ -135,6 +135,8 @@ class USBDriver {
         virtual bool isIdle(uint8_t ep) = 0;
         virtual int populateDefaultSerial(char *defSerial) = 0;
 
+        virtual void resume() = 0;
+
 
         USBManager *_manager;
 };
@@ -174,6 +176,8 @@ class USBFS : public USBDriver {
 
         bool isIdle(uint8_t ep);
         int populateDefaultSerial(char *defSerial);
+
+        void resume();
 
 		__attribute__ ((aligned(512))) volatile struct bdt _bufferDescriptorTable[16][4];
 
@@ -219,6 +223,8 @@ class USBHS : public USBDriver {
         void haltEndpoint(uint8_t ep);
         void resumeEndpoint(uint8_t ep);
         bool isIdle(uint8_t ep);
+
+        void resume();
 
         using USBDriver::_manager;
 
@@ -337,6 +343,10 @@ class USBManager {
             if (power < 0) power = 0;
             if (power > 500) power = 500;
             _devicePower = power / 2;
+        }
+
+        void resume() {
+            _driver->resume();
         }
 
 };

--- a/pic32/cores/pic32/USB_FS.cpp
+++ b/pic32/cores/pic32/USB_FS.cpp
@@ -414,5 +414,11 @@ int USBFS::populateDefaultSerial(char *defSerial) {
     return 14;
 }
 
+void USBFS::resume() {
+    U1CONbits.RESUME = 1;
+    delay(10);
+    U1CONbits.RESUME = 0;
+}
+
 #endif // __PIC32MX__
 #endif // _USB

--- a/pic32/cores/pic32/USB_HS.cpp
+++ b/pic32/cores/pic32/USB_HS.cpp
@@ -709,6 +709,12 @@ int USBHS::populateDefaultSerial(char *defSerial) {
     return 16;
 }
 
+void USBHS::resume() {
+    USBCSR0bits.RESUME = 1;
+    delay(10);
+    USBCSR0bits.RESUME = 0;
+}
+
 
 #endif // __PIC32MZ__
 #endif // _USB


### PR DESCRIPTION
Remote wakeup of the PC can now be achieved with `USB.resume();`.  It triggers the RESUME=1 / RESUME=0 sequence in the correct control register via the selected driver.