### PR TITLE
avoid copeing to buffer when sending

### DIFF
--- a/pic32/cores/pic32/chipKITVersion.h
+++ b/pic32/cores/pic32/chipKITVersion.h
@@ -1,7 +1,7 @@
 #ifndef _CHIPKIT_VERSION
 #define _CHIPKIT_VERSION
 
-// Version master-v2.0.5
-#define __CHIPKIT__ 20005
+// Version cdcacm_sendWithoutBlockCopy-v2.0.6-6-g66e01ad
+#define __CHIPKIT__ 20006
 
 #endif

--- a/pic32/cores/pic32/chipKITVersion.h
+++ b/pic32/cores/pic32/chipKITVersion.h
@@ -1,7 +1,7 @@
 #ifndef _CHIPKIT_VERSION
 #define _CHIPKIT_VERSION
 
-// Version cdcacm_sendWithoutBlockCopy-v2.0.6-6-g66e01ad
-#define __CHIPKIT__ 20006
+// Version master-v2.0.5
+#define __CHIPKIT__ 20005
 
 #endif


### PR DESCRIPTION
Hi
This i a performance optimization.

The code i used to test it is:
```
#include <USB.h>
#include <Timer.h>

#include "CDCSCM_F.h"
#include "USBManager_single.h"

Timer4 counter;

const uint32_t BUFFER_SIZE = 100000;

byte buffer[BUFFER_SIZE];
volatile uint32_t extraCounts = 0;

USBFS usbDriver;
USBManager USB(usbDriver, 0x04d8, 0x0f5d);
//USBManager_single USB(usbDriver, 0x04d8, 0x0f5d);
CDCACM usbOrig;
CDCACM_F usbFast;

void __USER_ISR isr() {
      extraCounts++;
      clearIntFlag(_TIMER_4_IRQ);
}

void setup() {

    Serial.begin(2000000);
    Serial.setTimeout(500);
    Serial.println("CDC speed test");


    USB.addDevice(usbFast);
    USB.addDevice(usbOrig);
    USB.begin();
    
    counter.setPrescaler(256);
    counter.setPeriod(0xFFFF);
    counter.setClockSource(TIMER_PB);
    counter.attachInterrupt(isr);

    for(uint32_t i = 0; i< BUFFER_SIZE;i++)
      buffer[i] = i & 0xff;
}

int32_t measure(Stream* s, uint32_t bytesPerWrite)
{
  counter.reset();
  extraCounts = 0;

  if(bytesPerWrite == 0)
  {
    uint32_t p = 0;
    counter.start();
    for(p = 0; p < BUFFER_SIZE; p++)
      s->write(buffer[p]);
  }
  else if(bytesPerWrite >= BUFFER_SIZE)
  {
    counter.start();
    s->write(buffer, bytesPerWrite);
  }
  else
  {
    uint32_t p = 0;
    counter.start();
    for(p = 0; p < BUFFER_SIZE-bytesPerWrite; p += bytesPerWrite)
      s->write(buffer+p, bytesPerWrite);
    if(BUFFER_SIZE-p) s->write(buffer+p, BUFFER_SIZE-p);
  }

  while(s->availableForWrite());
  counter.stop();
  
  extraCounts = (extraCounts <<16) + counter.getCount();
  
  double time = 1.0 / (((double)getPeripheralClock() / 256) / extraCounts);
  double bytes_per_secound = 1/time*BUFFER_SIZE;

  return bytes_per_secound;
}


//#define TEST_COUNT 36
//const uint32_t byteCounts[TEST_COUNT] = {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,20,21,22,23,25,27,28,30,31,32,33,63,64,65,255,256,257,BUFFER_SIZE};

#define TEST_COUNT 7
const uint32_t byteCounts[TEST_COUNT] = {0,1,2,4,8,32,BUFFER_SIZE};
 
void loop() 
{
  Serial.println("\n\n-------------------------");
  Serial.println("       |  Orig  |  fast   ");
  Serial.println("--------------------------");

  for(int i = 0; i < TEST_COUNT; i++)
  {
    Serial.print(byteCounts[i]);
    Serial.print(" | ");
    Serial.print(measure(&usbOrig, byteCounts[i]));
    Serial.print(" | ");
    Serial.println(measure(&usbFast, byteCounts[i]));
   // delay(2500);
  }
}
```
You will need a relay fast terminal or just pipe it to null device to see the speed improvement.
I used:
`stty -F /dev/ttyACM1 2000000 raw -echo -echoe -echok && cat /dttyACM1 > /dev/null`

I have seen speeds over 480k without -O3 option.
Over 500k with -O3 and block over 8 bytes.
The original with -O3 470k
The original without optimization is around 420k
