### PR TITLE
Faster cdcacm

### DIFF
--- a/pic32/cores/pic32/USB.h
+++ b/pic32/cores/pic32/USB.h
@@ -280,7 +280,7 @@ class USBManager {
 
 		USBManager(USBDriver *driver, uint16_t vid, uint16_t pid, const char *mfg = "chipKIT", const char *prod = _BOARD_NAME_, const char *ser = NULL);
 		USBManager(USBDriver &driver, uint16_t vid, uint16_t pid, const char *mfg = "chipKIT", const char *prod = _BOARD_NAME_, const char *ser = NULL) : 
-            USBManager(&driver, vid, pid, mfg, prod, ser) {}
+		USBManager(&driver, vid, pid, mfg, prod, ser) {}
 //		USBManager(USBDriver *driver, uint16_t vid, uint16_t pid);
 //		USBManager(USBDriver &driver, uint16_t vid, uint16_t pid);
 
@@ -412,7 +412,7 @@ class CDCACM : public USBDevice, public Stream {
 
         uint8_t _ctlA[8];
         uint8_t _ctlB[8];
-		size_t write(uint8_t b, bool enqueuePacket);
+		inline size_t write(uint8_t b, bool enqueuePacket);
 
     public:
         CDCACM() : _txHead(0), _txTail(0), _rxHead(0), _rxTail(0) {}

--- a/pic32/cores/pic32/USB.h
+++ b/pic32/cores/pic32/USB.h
@@ -412,6 +412,7 @@ class CDCACM : public USBDevice, public Stream {
 
         uint8_t _ctlA[8];
         uint8_t _ctlB[8];
+		size_t write(uint8_t b, bool enqueuePacket);
 
     public:
         CDCACM() : _txHead(0), _txTail(0), _rxHead(0), _rxTail(0) {}

--- a/pic32/cores/pic32/USB_CDCACM.cpp
+++ b/pic32/cores/pic32/USB_CDCACM.cpp
@@ -209,7 +209,7 @@ bool CDCACM::onInPacket(uint8_t ep, uint8_t target, uint8_t __attribute__((unuse
             avail = CDCACM_BULKEP_SIZE;
         }
         
-        if((_txTail + avail) > CDCACM_BUFFER_SIZE)
+        if((_txTail + avail) >= CDCACM_BUFFER_SIZE)
 		{
 			uint8_t tbuf[avail];
 			
@@ -290,7 +290,7 @@ size_t CDCACM::write(uint8_t b) {
             avail = CDCACM_BULKEP_SIZE;
         }
 		
-		if((_txTail + avail) > CDCACM_BUFFER_SIZE)
+		if((_txTail + avail) >= CDCACM_BUFFER_SIZE)
 		{
 			uint8_t tbuf[avail];
 			
@@ -313,7 +313,7 @@ size_t CDCACM::write(uint8_t b) {
     return 1;
 }
 
-size_t CDCACM::write(uint8_t b, bool enqueuePacket) {
+inline size_t CDCACM::write(uint8_t b, bool enqueuePacket) {
 
     //if (_lineState == 0) return 0;
 
@@ -336,7 +336,7 @@ size_t CDCACM::write(uint8_t b, bool enqueuePacket) {
             avail = CDCACM_BULKEP_SIZE;
         }
 		
-		if((_txTail + avail) > CDCACM_BUFFER_SIZE)
+		if((_txTail + avail) >= CDCACM_BUFFER_SIZE)
 		{
 			uint8_t tbuf[avail];
 			
@@ -366,7 +366,7 @@ size_t CDCACM::write(const uint8_t *b, size_t len) {
     for (uint32_t i = 0; i < len; i++) {
 		bool equ = (i == len-1) || 										// enqueue if last byte
 					(i != 0 && i % CDCACM_BULKEP_SIZE == 0) ||				// enqueue on every full bulk buffer size
-					(((CDCACM_BUFFER_SIZE + _txHead - _txTail) % CDCACM_BUFFER_SIZE) < CDCACM_BUFFER_HIGH); // enqueue when the cdc x buffer is high
+					(((CDCACM_BUFFER_SIZE + _txHead - _txTail) % CDCACM_BUFFER_SIZE) < CDCACM_BUFFER_HIGH); // enqueue when the cdc tx buffer is high
 		write(b[i], equ);
     }
     

--- a/pic32/cores/pic32/USB_CDCACM.cpp
+++ b/pic32/cores/pic32/USB_CDCACM.cpp
@@ -271,8 +271,8 @@ size_t CDCACM::write(uint8_t b) {
 
     if (_lineState == 0) return 0;
 
-    volatile uint32_t h = _txHead;
-    volatile uint32_t newhead = (h + 1) % CDCACM_BUFFER_SIZE;
+    uint32_t h = _txHead;
+    uint32_t newhead = (h + 1) % CDCACM_BUFFER_SIZE;
 
     // Wait for room
     while (newhead == _txTail) {
@@ -313,11 +313,61 @@ size_t CDCACM::write(uint8_t b) {
     return 1;
 }
 
+size_t CDCACM::write(uint8_t b, bool enqueuePacket) {
+
+    //if (_lineState == 0) return 0;
+
+    uint32_t h = _txHead;
+    uint32_t newhead = (h + 1) % CDCACM_BUFFER_SIZE;
+
+    // Wait for room
+    while (newhead == _txTail) {
+        h = _txHead;
+        newhead = (h + 1) % CDCACM_BUFFER_SIZE;
+    }
+
+    _txBuffer[newhead] = b;
+    _txHead = newhead;
+
+    if (enqueuePacket && _manager->canEnqueuePacket(_epBulk)) {
+        uint32_t s = disableInterrupts();
+        uint32_t avail = (CDCACM_BUFFER_SIZE + _txHead - _txTail) % CDCACM_BUFFER_SIZE;
+        if (avail > CDCACM_BULKEP_SIZE) {
+            avail = CDCACM_BULKEP_SIZE;
+        }
+		
+		if((_txTail + avail) > CDCACM_BUFFER_SIZE)
+		{
+			uint8_t tbuf[avail];
+			
+			for (uint32_t i = 0; i < avail; i++) {
+				_txTail = (_txTail + 1) % CDCACM_BUFFER_SIZE;
+				tbuf[i] = _txBuffer[_txTail];
+			}
+			_manager->enqueuePacket(_epBulk, tbuf, avail);
+		}
+		else
+		{
+			_manager->enqueuePacket(_epBulk, _txBuffer + _txTail+1, avail);
+			_txTail = (_txTail + avail) % CDCACM_BUFFER_SIZE;
+		}
+		
+        restoreInterrupts(s);
+    }
+
+//    _manager->sendBuffer(_epBulk, &b, 1);
+    return 1;
+}
+
 size_t CDCACM::write(const uint8_t *b, size_t len) {
 
     if (_lineState == 0) return 0;
+	
     for (uint32_t i = 0; i < len; i++) {
-        write(b[i]);
+		bool equ = (i == len-1) || 										// enqueue if last byte
+					(i != 0 && i % CDCACM_BULKEP_SIZE == 0) ||				// enqueue on every full bulk buffer size
+					(((CDCACM_BUFFER_SIZE + _txHead - _txTail) % CDCACM_BUFFER_SIZE) < CDCACM_BUFFER_HIGH); // enqueue when the cdc x buffer is high
+		write(b[i], equ);
     }
     
 /*


### PR DESCRIPTION
Hi
This change enables the CDCACM to send with around 1M.
With -Os the buffer send should be at lest around 32byte-
With -O3 already with 4 bytes 1M is reached.
It is only reached when there is only one USB device registers in the USBManager.
It depents on PR #446