### PR TITLE
Added SDVOL pullup control and definition

### DIFF
--- a/pic32/libraries/DSDVOL/DSDVOL.cpp
+++ b/pic32/libraries/DSDVOL/DSDVOL.cpp
@@ -26,8 +26,12 @@ void DSDVOL::power_on (void)
 {
     pinMode(_csPin, OUTPUT);
     digitalWrite(_csPin, HIGH);
-    dSDspi.begin();
+    #ifdef _SD_SDI_PIN
+    pinMode(_SD_SDI_PIN, INPUT_PULLUP);
+    #endif
  
+    dSDspi.begin();
+
     dSDspi.setMode(DSPI_MODE0);
     FCLK_FAST();
 }
@@ -36,6 +40,9 @@ void DSDVOL::power_off (void)
 {
     dSDspi.end();
     pinMode(_csPin, INPUT);
+    #ifdef _SD_SDI_PIN
+    pinMode(_SD_SDI_PIN, INPUT);
+    #endif
 }
 
 /*-----------------------------------------------------------------------*/

--- a/pic32/variants/WiFire/Board_Defs.h
+++ b/pic32/variants/WiFire/Board_Defs.h
@@ -437,6 +437,7 @@ extern const uint8_t	digital_pin_to_pps_in_PGM[];
 #define _DSPI2_MOSI_OUT		PPS_OUT_SDO3
 #define _DSPI2_MOSI_PIN		54		    // RA4  SDO1    RPA4R = SDO1 = 3
 
+
 // this is the MRF24
 #define	_DSPI3_BASE			_SPI4_BASE_ADDRESS
 #define	_DSPI3_ERR_IRQ		_SPI4_FAULT_VECTOR
@@ -538,7 +539,8 @@ extern int convertADC(uint8_t channelNumber);
 #define SD_SCK_PPS()        RPB14R  = 0b0000    // Bit Banging SPI, set as GPIO
 
 #define DefineSDSPI(spi) DSPI2 spi
-#define DefineDSDVOL(vol, spi) DSDVOL vol(spi, 53)     // Create an DSDVOL object
+#define DefineDSDVOL(vol, spi) DSDVOL vol(spi, PIN_DSPI2_SS)     // Create an DSDVOL object
+#define _SD_SDI_PIN _DSPI2_MISO_PIN
 
 /* ------------------------------------------------------------ */
 /*					Defines for the On Board MRF24				*/


### PR DESCRIPTION
Also fixed the chip select pin number for the WiFire.

The theory here is quite simple:

* SDVOL was changed some time back to take a chip select pin instead of a pullup pin (for obvious reasons)
* No facility for controlling the pullup pin was retained
* This puts that facility back in using a simple #define in the board definition