### PR TITLE
Fixed I2C / Wire Class not working on QuicK240

### DIFF
--- a/pic32/variants/PONTECH_Quick240/Board_Data.c
+++ b/pic32/variants/PONTECH_Quick240/Board_Data.c
@@ -21,6 +21,7 @@
 /*																		*/
 /*	11/28/2011(GeneA): Created by splitting data out of Board_Defs.h	*/
 /*	03/31/2012(GeneA): added support for second LED on Rev D boards		*/
+/*	04/14/2019(J.Christ): removed dependency on Microchip plib library	*/
 /*																		*/
 /************************************************************************/
 //*	This library is free software; you can redistribute it and/or
@@ -42,7 +43,7 @@
 #if !defined(BOARD_DATA_C)
 #define BOARD_DATA_C
 
-#include <inttypes.h>
+#include <Arduino.h>
 
 /* ------------------------------------------------------------ */
 /*					Data Tables									*/
@@ -399,12 +400,101 @@ const uint16_t digital_pin_to_timer_PGM[] = {
 	NOT_ON_TIMER,		//	86 RC1	T2CK/RC1
 };
 
-/* ------------------------------------------------------------ */
-/*		Include Files for Board Customization Functions			*/
-/* ------------------------------------------------------------ */
+const uint32_t digital_pin_to_cn_PGM[] =
+{
+    NOT_CN_PIN,         //	0 RF2	SDA1A/SDI1A/U1ARX/RF2                                                                                                                                          
+    NOT_CN_PIN,         //	1 RF8	SCL1A/SDO1A/U1ATX/RF8                                                                                                                                    
+    NOT_CN_PIN,         //	2 RE8	AERXD0/INT1/RE8                                                                                                                                    
+    NOT_CN_PIN,         //	3 RD0	SDO1/OC1/INT0/RD0                                                                                                                                    
+    _BV(0),             //	4 RC14	SOSCO/T1CK/CN0/RC14                                                                                                                                    
+    NOT_CN_PIN,         //	5 RD1	OC2/RD1                                                                                                                                    
+    NOT_CN_PIN,         //	6 RD2	OC3/RD2                                                                                                                                    
+    NOT_CN_PIN,         //	7 RE9	AERXD1/INT2/RE9                                                                                                                                    
+    NOT_CN_PIN,         //	8 RD12	ETXD2/IC5/PMD12/RD12                                                                                                                                    
+    NOT_CN_PIN,         //	9 RD3	OC4/RD3                                                                                                                                    
+    _BV(13),            //	10 RD4	OC5/PMWR/CN13/RD4                                                                                                                                    
+    NOT_CN_PIN,         //	11 RC4	T5CK/SDI1/RC4                                                                                                                                    
+    NOT_CN_PIN,         //	12 RA2	SCL2/RA2                                                                                                                                    
+    NOT_CN_PIN,         //	13 RA3	SDA2/RA3                                                                                                                                    
+    NOT_CN_PIN,         //	14 RF13	AC1TX/SCK3A/U3BTX/U3ARTS/RF13                                                                                                                                    
+    NOT_CN_PIN,         //	15 RF12	AC1RX/SS3A/U3BRX/U3ACTS/RF12                                                                                                                                    
+    _BV(18),            //	16 RF5	SCL3A/SDO3A/U3ATX/PMA8/CN18/RF5                                                                                                                                    
+    _BV(17),            //	17 RF4	SDA3A/SDI3A/U3ARX/PMA9/CN17/RF4                                                                                                                                    
+    _BV(21),            //	18 RD15	AETXD1/SCK1A/U1BTX/U1ARTS/CN21/RD15                                                                                                                                    
+    _BV(20),            //	19 RD14	AETXD0/SS1A/U1BRX/U1ACTS/CN20/RD14                                                                                                                                    
+    NOT_CN_PIN,         //	20 RA15	AETXEN/SDA1/INT4/RA15                                                                                                                                    
+    NOT_CN_PIN,         //	21 RA14	AETXCLK/SCL1/INT3/RA14                                                                                                                                    
+    NOT_CN_PIN,         //	22 RC2	T3CK/AC2TX/RC2                                                                                                                                    
+    NOT_CN_PIN,         //	23 RC3	T4CK/AC2RX/RC3                                                                                                                                    
+    NOT_CN_PIN,         //	24 VBUS                                                                                                                                    
+    NOT_CN_PIN,         //	25 RF3	USBID/RF3                                                                                                                                    
+    NOT_CN_PIN,         //	26 RG3	D-/RG3                                                                                                                                    
+    NOT_CN_PIN,         //	27 RG2	D+/RG2                                                                                                                                    
+    NOT_CN_PIN,         //	28 RG15                                                                                                                                    
+    _BV(9),             //	29 RG7	ECRS/SDA2A/SDI2A/U2ARX/PMA4/CN9/RG7                                                                                                                                    
+    NOT_CN_PIN,         //	30 RE7	PMD7/RE7                                                                                                                                    
+    NOT_CN_PIN,         //	31 RE6	PMD6/RE6                                                                                                                                    
+    NOT_CN_PIN,         //	32 RE5	PMD5/RE5                                                                                                                                    
+    NOT_CN_PIN,         //	33 RE4	PMD4/RE4                                                                                                                                    
+    NOT_CN_PIN,         //	34 RE3	PMD3/RE3                                                                                                                                    
+    NOT_CN_PIN,         //	35 RE2	PMD2/RE2                                                                                                                                    
+    NOT_CN_PIN,         //	36 RE1	PMD1/RE1                                                                                                                                    
+    NOT_CN_PIN,         //	37 RE0	PMD0/RE0                                                                                                                                    
+    NOT_CN_PIN,         //	38 RD10	SCK1/IC3/PMCS2/PMA15/RD10                                                                                                                                    
+    _BV(14),            //	39 RD5	PMRD/CN14/RD5                                                                                                                                    
+    NOT_CN_PIN,         //	40 RB11	AN11/EREXERR/AETXERR/PMA12/RB11                                                                                                                                    
+    NOT_CN_PIN,         //	41 RB13	AN13/ERXD1/AECOL/PMA10/RB13                                                                                                                                    
+    NOT_CN_PIN,         //	42 RB12	AN12/ERXD0/AECRS/PMA11/RB12                                                                                                                                    
+    _BV(10),            //	43 RG8	ERXDV/AERXDV/ECRSDV/AECRSDV/SCL2A/SDO2A/U2ATX/PMA3/CN10/RG8                                                                                                                                    
+    NOT_CN_PIN,         //	44 RA10	VREF+/CVREF+/AERXD3/PMA6/RA10                                                                                                                                    
+    NOT_CN_PIN,         //	45 RF0	C1RX/ETXD1/PMD11/RF0                                                                                                                                    
+    NOT_CN_PIN,         //	46 RF1	C1TX/ETXD0/RMD10/RF1                                                                                                                                    
+    _BV(15),            //	47 RD6	ETXEN/PMD14/CN15/RD6                                                                                                                                    
+    NOT_CN_PIN,         //	48 RD8	RTCC/EMDIO/AEMDIO/IC1/RD8                                                                                                                                    
+    NOT_CN_PIN,         //	49 RD11	EMDC/AEMDC/IC4/PMCS1/PMA14/RD11                                                                                                                                    
+    _BV(9),             //	50 RG7	ECRX/SDA2/SDI2A/U2ARX/PMA4/CN9/RG7                                                                                                                                    
+    NOT_CN_PIN,         //	51 RG8                                                                                                                                    
+    _BV(8),             //	52 RG6	ECOL/SCK2A/U2BTX/U2ARTS/PMA5/CN8/RG6                                                                                                                                    
+    _BV(11),            //	53 RG9	ERXCLK/AERXCLK/EREFCLK/AEREFCLK/SS2A/U2BRX/U2ACTS/PMA2/CN11/RG9                                                                                                                                    
+    _BV(2),             //	54	RB0	PGED1/AN0/CN2/RB0                                                                                                                                    
+    _BV(3),             //	55	RB1	PGEC1/AN1/CN3/RB1                                                                                                                                    
+    _BV(4),             //	56	RB2	AN2/C2IN-/CN4/RB2                                                                                                                                    
+    _BV(5),             //	57	RB3	AN3/C2IN+/CN5/RB3                                                                                                                                    
+    _BV(6),             //	58	RB4	AN4/C1IN-/CN6/RB4                                                                                                                                    
+    _BV(7),             //	59	RB5	AN5/C1IN+/VBUSON/CN7/RB5                                                                                                                                    
+    NOT_CN_PIN,         //	60	RB6	PGEC2/AN6/OCFA/RB6                                                                                                                                    
+    NOT_CN_PIN,         //	61	RB7	PGED2/AN7/RB7                                                                                                                                    
+    NOT_CN_PIN,         //	62	RB8	AN8/C1OUT/RB8                                                                                                                                    
+    NOT_CN_PIN,         //	63	RB9	AN9/C2OUT/RB9                                                                                                                                    
+    NOT_CN_PIN,         //	64	RB10	AN10/CVREFOUT/PMA13/RB10                                                                                                                                    
+    NOT_CN_PIN,         //	65	RB11	AN11/EREXERR/AETXERR/PMA12/RB11                                                                                                                                    
+    NOT_CN_PIN,         //	66	RB12	AN13/ERXD1/AECOL/PMA10/RB13                                                                                                                                    
+    NOT_CN_PIN,         //	67	RB13	AN12/ERXD0/AECRS/PMA11/RB12                                                                                                                                    
+    NOT_CN_PIN,         //	68	RB14	AN14/ERXD2/AETXD3/PMALH/PMA1/RB14                                                                                                                                    
+    _BV(12),            //	69	RB15	AN15/ERXD3/AETXD2/OCFB/PMALL/PMA0/CN12/RB15                                                                                                                                    
+    NOT_CN_PIN,         //	70 RA0	TMS/RA0                                                                                                                                    
+    NOT_CN_PIN,         //	71 RA1	TCK/RA1                                                                                                                                    
+    NOT_CN_PIN,         //	72 RA4	TDI/RA4                                                                                                                                     
+    NOT_CN_PIN,         //	73 RA5	TDO/RA5                                                                                                                                    
+    NOT_CN_PIN,         //	74 RD9	SS1/IC2/RD9                                                                                                                                     
+    _BV(1),             //	75 RC13	SOSCI/CN1/RC13                                                                                                                                    
+    _BV(19),            //	76 RD13	ETXD3/PMD13/CN19/RD13                                                                                                                                    
+    _BV(16),            //	77 RD7	ETXCLK/PMD15/CN16/RD7                                                                                                                                    
+    NOT_CN_PIN,         //	78 RG1	C2TX/ETXERR/PMD9/RG1                                                                                                                                    
+    NOT_CN_PIN,         //	79 RG0	C2RX/PMD8/RG0                                                                                                                                    
+    NOT_CN_PIN,         //	80 RA6	TRCLK/RA6                                                                                                                                    
+    NOT_CN_PIN,         //	81 RA7	TRD3/RA7                                                                                                                                    
+    NOT_CN_PIN,         //	82 RG14	TRD2/RG14                                                                                                                                    
+    NOT_CN_PIN,         //	83 RG12	TRD1/RG12                                                                                                                                    
+    NOT_CN_PIN,         //	84 RG13	TRD0/RG13                                                                                                                                    
+    NOT_CN_PIN,         //	85 RA9	VREF-/CVREF0/AERXD2/PMA7/RA9                                                                                                                                    
+    NOT_CN_PIN,         //	86 RC1	T2CK/RC1                                                                                                                                    
+};                                                                                                                                                          
+                                                                                                                                                            
+/* ------------------------------------------------------------ */                                                                                          
+/*		Include Files for Board Customization Functions			*/                                                                                          
+/* ------------------------------------------------------------ */                                                                                          
 
-#if	(OPT_BOARD_INIT != 0)
-#endif
 
 /* ------------------------------------------------------------ */
 /*				Board Customization Functions					*/
@@ -440,9 +530,15 @@ const uint16_t digital_pin_to_timer_PGM[] = {
 */
 #if	(OPT_BOARD_INIT != 0)
 extern void _disableSeconaryOscillator(void);
+
 void _board_init(void) {
+
+    /*	Turn off Secondary oscillator so pins can be used as GPIO */
+
     _disableSeconaryOscillator();
-}   
+
+}
+
 #endif
 
 /* ------------------------------------------------------------ */

--- a/pic32/variants/PONTECH_Quick240/Board_Defs.h
+++ b/pic32/variants/PONTECH_Quick240/Board_Defs.h
@@ -54,12 +54,8 @@
 ** refer to periperhals on the board generically.
 */
 
-#define	_BOARD_NAME_	"chipKIT Max32"
+#define	_BOARD_NAME_	"PONTECH Quick240"
 #define _USB
-
-#define VIRTUAL_PROGRAM_BUTTON_TRIS TRISGbits.TRISG15
-#define VIRTUAL_PROGRAM_BUTTON LATGbits.LATG15
-#define USE_VIRTUAL_PROGRAM_BUTTON 1
 
 /* Define the Microcontroller peripherals available on the board.
 */
@@ -90,49 +86,6 @@
 */
 #define	NUM_DIGITAL_PINS_EXTENDED	NUM_DIGITAL_PINS
 #define	NUM_ANALOG_PINS_EXTENDED	NUM_ANALOG_PINS
-
-#define C0ADR 32
-#define C1ADR 31
-#define C2ADR 30
-#define C3ADR 52
-#define C4ADR 29
-#define C5ADR 85
-
-#define C0IO0 68
-#define C0IO1 58
-#define C0IO2 62
-#define C0IO3 55
-#define C0IO4 82
-
-#define C1IO0 57
-#define C1IO1 56
-#define C1IO2 63
-#define C1IO3 54
-#define C1IO4 83
-
-#define C2IO0 86
-#define C2IO1 64
-#define C2IO2 5
-#define C2IO3 70
-#define C2IO4 84
-
-#define C3IO0 22
-#define C3IO1 76
-#define C3IO2 9
-#define C3IO3 2
-#define C3IO4 35
-
-#define C4IO0 23
-#define C4IO1 39
-#define C4IO2 8
-#define C4IO3 21
-#define C4IO4 34
-
-#define C5IO0 78
-#define C5IO1 79
-#define C5IO2 10
-#define C5IO3 20
-#define C5IO4 33
 
 /* ------------------------------------------------------------ */
 /*						LED Declarations						*/
@@ -279,16 +232,11 @@ static const uint8_t SCK  = 38;		// PIC32 SCK2A
 #define digitalPinToTimerOC(P) ( (digital_pin_to_timer_PGM[P] & _MSK_TIMER_OC)  )
 #define digitalPinToTimerIC(P) ( (digital_pin_to_timer_PGM[P] & _MSK_TIMER_IC)  )
 #define digitalPinToTimerTCK(P) ( (digital_pin_to_timer_PGM[P] & _MSK_TIMER_TCK)  )
-// Already defined in pins_arduino.h
-//#define	digitalPinToTimer(P)	digitalPinToTimerOC(P)
-//#define portRegisters(P) ( port_to_tris_PGM[P])
-//#define portModeRegister(P) ( (volatile uint32_t *)port_to_tris_PGM[P] )
-//#define portInputRegister(P) ( (volatile uint32_t *)(port_to_tris_PGM[P] + 0x0010) )
-//#define portOutputRegister(P) ( (volatile uint32_t *)(port_to_tris_PGM[P] + 0x0020) )
 #undef digitalPinToAnalog
 #define	digitalPinToAnalog(P) ( (P) < 16 ? (P) : ((P) >= 54) && ((P) < 70) ? (P)-54 : NOT_ANALOG_PIN )
-// (This is the default from pins_arduino.h, so no define needs to be done here)
-//#define analogInPinToChannel(P) ( P )
+
+#undef digitalPinToCN
+#define digitalPinToCN(P) ( digital_pin_to_cn_PGM[P] )
 
 /* ------------------------------------------------------------ */
 /*					Data Definitions							*/
@@ -304,6 +252,7 @@ extern const uint32_t	port_to_tris_PGM[];
 extern const uint8_t	digital_pin_to_port_PGM[];
 extern const uint16_t	digital_pin_to_bit_mask_PGM[];
 extern const uint16_t	digital_pin_to_timer_PGM[];
+extern const uint32_t   digital_pin_to_cn_PGM[];
 
 #endif
 
@@ -357,6 +306,10 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define _SER0_IPL_ISR	IPL2SOFT
 #define	_SER0_IPL		2
 #define	_SER0_SPL		0
+#define _SER0_TX_PIN    1
+#define _SER0_RX_PIN    0
+#define _SER0_RTS_PIN   18
+#define _SER0_CTS_PIN   19
 
 /* Serial port 1 uses UART4 (aka UART1B)
 */
@@ -366,6 +319,8 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define _SER1_IPL_ISR	IPL2SOFT
 #define	_SER1_IPL		2
 #define	_SER1_SPL		0
+#define _SER1_TX_PIN    18
+#define _SER1_RX_PIN    19
 
 /* Serial port 2 uses UART2 (aka UART3A)
 */
@@ -375,6 +330,10 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define _SER2_IPL_ISR	IPL2SOFT
 #define	_SER2_IPL		2
 #define	_SER2_SPL		0
+#define _SER2_TX_PIN    16
+#define _SER2_RX_PIN    17
+#define _SER2_RTS_PIN   14
+#define _SER2_CTS_PIN   15
 
 /* Serial port 3 uses UART5 (aka UART3B)
 */
@@ -384,6 +343,8 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define _SER3_IPL_ISR	IPL2SOFT
 #define	_SER3_IPL		2
 #define	_SER3_SPL		0
+#define _SER3_TX_PIN   14
+#define _SER3_RX_PIN   15
 
 /* ------------------------------------------------------------ */
 /*					SPI Port Declarations						*/
@@ -454,23 +415,23 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 **		DTWI3:	SDA pin 29, SCL pin 43
 **		DTWI4:	SDA pin 17, SCL pin 16
 */
-#define	_DTWI0_BASE		_I2C1_BASE_ADDRESS
-#define	_DTWI0_BUS_IRQ	_I2C1_BUS_IRQ
-#define	_DTWI0_VECTOR	_I2C_1_VECTOR
+#define	_DTWI0_BASE		_I2C2_BASE_ADDRESS
+#define	_DTWI0_BUS_IRQ	_I2C2_BUS_IRQ
+#define	_DTWI0_VECTOR	_I2C_2_VECTOR
 #define	_DTWI0_IPL_ISR	IPL3SOFT
 #define	_DTWI0_IPL		3
 #define	_DTWI0_SPL		0
-#define _DTWI0_SCL_PIN  21 
-#define _DTWI0_SDA_PIN  20
+#define _DTWI0_SCL_PIN  12 
+#define _DTWI0_SDA_PIN  13
 
-#define	_DTWI1_BASE		_I2C2_BASE_ADDRESS
-#define	_DTWI1_BUS_IRQ	_I2C2_BUS_IRQ
-#define	_DTWI1_VECTOR	_I2C_2_VECTOR
+#define	_DTWI1_BASE		_I2C1_BASE_ADDRESS
+#define	_DTWI1_BUS_IRQ	_I2C1_BUS_IRQ
+#define	_DTWI1_VECTOR	_I2C_1_VECTOR
 #define	_DTWI1_IPL_ISR	IPL3SOFT
 #define	_DTWI1_IPL		3
 #define	_DTWI1_SPL		0
-#define _DTWI1_SCL_PIN  12 
-#define _DTWI1_SDA_PIN  13
+#define _DTWI1_SCL_PIN  21 
+#define _DTWI1_SDA_PIN  20
 
 #define	_DTWI2_BASE		_I2C3_BASE_ADDRESS
 #define	_DTWI2_BUS_IRQ	_I2C3_BUS_IRQ
@@ -499,16 +460,33 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define _DTWI4_SCL_PIN  16 
 #define _DTWI4_SDA_PIN  17
 
+
 /* ------------------------------------------------------------ */
 /*					A/D Converter Declarations					*/
 /* ------------------------------------------------------------ */
 
-
+/* ------------------------------------------------------------ */
+/* ------------------------------------------------------------ */
+/*					Defines for the WiFiShield uSD				*/
 /* ------------------------------------------------------------ */
 
+
+
+
+
+
+
+
+
+
+
+
+
+
 /* ------------------------------------------------------------ */
-/*					Defines for Network                  */
+/*					Defines for Network Shield                  */
 /* ------------------------------------------------------------ */
+
 #define _IM8720PHY_PIN_CONFIG_
 
 #define PHY_TRIS            (TRISEbits.TRISE9)        // = 0; output
@@ -516,6 +494,54 @@ extern const uint16_t	digital_pin_to_timer_PGM[];
 #define PHY_ADDRESS         0x5                     // something other than 0 or 1 (although 1 is okay)
 
 /* ------------------------------------------------------------ */
+
+#define USE_VIRTUAL_PROGRAM_BUTTON 1
+#define VIRTUAL_PROGRAM_BUTTON_TRIS TRISGbits.TRISG15
+#define VIRTUAL_PROGRAM_BUTTON LATGbits.LATG15
+
+
+#define C0ADR 32
+#define C1ADR 31
+#define C2ADR 30
+#define C3ADR 52
+#define C4ADR 29
+#define C5ADR 85
+
+#define C0IO0 68
+#define C0IO1 58
+#define C0IO2 62
+#define C0IO3 55
+#define C0IO4 82
+
+#define C1IO0 57
+#define C1IO1 56
+#define C1IO2 63
+#define C1IO3 54
+#define C1IO4 83
+
+#define C2IO0 86
+#define C2IO1 64
+#define C2IO2 5
+#define C2IO3 70
+#define C2IO4 84
+
+#define C3IO0 22
+#define C3IO1 76
+#define C3IO2 9
+#define C3IO3 2
+#define C3IO4 35
+
+#define C4IO0 23
+#define C4IO1 39
+#define C4IO2 8
+#define C4IO3 21
+#define C4IO4 34
+
+#define C5IO0 78
+#define C5IO1 79
+#define C5IO2 10
+#define C5IO3 20
+#define C5IO4 33
 
 #endif	// BOARD_DEFS_H
 


### PR DESCRIPTION
Updated the board variants files.