### PR TITLE
#240 Made Wire receiveFrom stopMaster() optional

### DIFF
--- a/pic32/libraries/Wire/Wire.cpp
+++ b/pic32/libraries/Wire/Wire.cpp
@@ -182,7 +182,7 @@ void TwoWire::begin(int address)
     begin((uint8_t)address);
 }
 
-uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
+uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, bool sendstop)
 {
     DTWI::I2C_STATUS i2cStatus = di2c.getStatus();
 
@@ -201,14 +201,16 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity)
         i2cStatus = di2c.getStatus();
     } while(i2cStatus.fMyBus && !i2cStatus.fNacking);
 
-    while(!di2c.stopMaster());
+    if (sendstop) {
+        while(!di2c.stopMaster());
+    }
 
     return(di2c.available());
 }
 
-uint8_t TwoWire::requestFrom(int address, int quantity)
+uint8_t TwoWire::requestFrom(int address, int quantity, bool sendstop)
 {
-  return requestFrom((uint8_t)address, (uint8_t)quantity);
+  return requestFrom((uint8_t)address, (uint8_t)quantity, sendstop);
 }
 
 void TwoWire::beginTransmission(uint8_t address)

--- a/pic32/libraries/Wire/Wire.h
+++ b/pic32/libraries/Wire/Wire.h
@@ -98,8 +98,8 @@ class TwoWire
     void beginTransmission(int);
     uint8_t endTransmission(void);
     uint8_t endTransmission(uint8_t);
-    uint8_t requestFrom(uint8_t, uint8_t);
-    uint8_t requestFrom(int, int);
+    uint8_t requestFrom(uint8_t, uint8_t, bool=true);
+    uint8_t requestFrom(int, int, bool=true);
     void __attribute__((deprecated("Use write() instead"))) send(uint8_t);
     void __attribute__((deprecated("Use write() instead"))) send(uint8_t*, uint8_t);
     void __attribute__((deprecated("Use write() instead"))) send(int);


### PR DESCRIPTION
This adds an optional boolean parameter to `Wire.requestFrom()` which then is used to wrap the `di2c.stopMaster()` call to make executing it optional.
