### PR TITLE
WIP: Add GitHub actions

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,65 @@
+name: Ant CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: | # we have to make sure to get the tags
+          git fetch --unshallow --prune --tags
+          git tag --list
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Build core zips for each platform
+        run: ant -noinput -buildfile build.xml dist-all
+
+      - name: Archive linux32
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux32
+          path: dist/linux32/chipkit-core-*.zip
+          if-no-files-found: error
+
+      - name: Archive linux64
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux64
+          path: dist/linux64/chipkit-core-*.zip
+          if-no-files-found: error
+
+      - name: Archive arm
+        uses: actions/upload-artifact@v2
+        with:
+          name: arm
+          path: dist/arm/chipkit-core-*.zip
+          if-no-files-found: error
+
+      - name: Archive macosx
+        uses: actions/upload-artifact@v2
+        with:
+          name: macosx
+          path: dist/macosx/chipkit-core-*.zip
+          if-no-files-found: error
+
+      - name: Archive windows
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows
+          path: dist/windows/chipkit-core-*.zip
+          if-no-files-found: error
+
+# Instead of archiving each one, you could archive them in a single artifact.
+#
+#      - name: Archive all core zips
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: corezips
+#          path: dist/*/chipkit-core-*.zip
+#          if-no-files-found: error

--- a/build.xml
+++ b/build.xml
@@ -102,7 +102,7 @@
     </copy>
 
     <copy tofile="dist/${localplatform}/chipkit-core/pic32/tools/bin/pic32prog"
-            file="modules/pic32prog-autotools/bin/pic32prog-osx-fat"
+            file="modules/pic32prog-autotools/bin/pic32prog-osx"
     />
 
     <chmod perm="+x">


### PR DESCRIPTION
I set up Github Actions.

The file is in `.github/workflows/ant.ci`.  I am not an expert at GitHub Actions, but I think this replicates what we were doing with the core before on the Wayne and Layne Jenkins box.

GitHub expires the artifacts after a bit, so we'll still need to use Releases for long term archiving, I think.

(There are fun things we can do with this in the future too, like https://github.com/actions/create-release.)

