### PR TITLE
Update Wire.cpp

### DIFF
--- a/pic32/libraries/Wire/Wire.cpp
+++ b/pic32/libraries/Wire/Wire.cpp
@@ -240,6 +240,9 @@ uint8_t TwoWire::endTransmission(uint8_t fStopBit)
     // a collision or the slave acked, in either case report a NACK from the slave
     if(!di2c.getStatus().fMyBus)
     {
+        //Make sure to discard transmit buffer if slave NACK, otherwise next beginTransmission will freeze system
+        di2c.abort();
+        
         return(2);
     }
 


### PR DESCRIPTION
Bugfix, when slave NACK received, next transmission would freeze system due to transmit buffer not empty from previous transmission.

This can happen when a slave disappears from the bus. In my example the SCL would stay low and my clicker 2 board would freeze completely due to while loop in beginTransmission that blocks until transmit buffer is empty.
![Wire freeze when slave disappears](https://user-images.githubusercontent.com/25741129/187026031-a5bfc735-dde4-483d-904a-20940375dfb6.jpg)
![Wire one packet before](https://user-images.githubusercontent.com/25741129/187026094-5d0c3b9a-cbad-4602-bbe4-fa8e947f8f5f.jpg)
